### PR TITLE
[REFACTOR]#150 공통 응답 포맷, 스프링 시큐리티 응답 포맷 리팩토링

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/global/response/domain/ServiceCode.java
+++ b/src/main/java/org/hanihome/hanihomebe/global/response/domain/ServiceCode.java
@@ -90,13 +90,6 @@ public enum ServiceCode {
     NOTIFICATION_SEND_FAILED(HttpStatus.BAD_REQUEST, "알림 전송에 실패했습니다"),
     NOT_DEFINED_ERROR_FROM_FILTER(HttpStatus.BAD_REQUEST, "정의 되지 않은 에러입니다 from 필터"),
     NOT_DEFINED_ERROR(HttpStatus.BAD_REQUEST, "정의 되지 않은 에러입니다"),
-
-    //dispacherservlet
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "올바른 요청이 아닙니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 URL입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러"),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "사용자가 인증되지 않았습니다"),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증은 되었지만 권한이 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/hanihome/hanihomebe/global/response/domain/ServiceCode.java
+++ b/src/main/java/org/hanihome/hanihomebe/global/response/domain/ServiceCode.java
@@ -84,6 +84,7 @@ public enum ServiceCode {
     METRO_STOP_SYNCHRONIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "시드니 지하철역 동기화 중 오류가 발생했습니다"),
     METRO_STOPS_FILE_IS_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "저장된 stops.txt 파일이 비어있습니다."),
 
+    // Report
     PROPERTY_REPORT(HttpStatus.BAD_REQUEST,"매물 신고만 가능합니다"),
 
     // not defined

--- a/src/main/java/org/hanihome/hanihomebe/global/response/dto/CommonResponse.java
+++ b/src/main/java/org/hanihome/hanihomebe/global/response/dto/CommonResponse.java
@@ -51,13 +51,4 @@ public class CommonResponse<T> {
                 .data(data)
                 .build();
     }
-
-    public static <T> CommonResponse<T> failure(ServiceCode code) {
-        return CommonResponse.<T>builder()
-                .isSuccess(false)
-                .serviceCode(code.name())
-                .message(code.getMessage())
-                .data(null)
-                .build();
-    }
 }

--- a/src/main/java/org/hanihome/hanihomebe/global/response/wrapper/GlobalResponseWrapper.java
+++ b/src/main/java/org/hanihome/hanihomebe/global/response/wrapper/GlobalResponseWrapper.java
@@ -2,8 +2,6 @@ package org.hanihome.hanihomebe.global.response.wrapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.global.response.dto.CommonResponse;
 import org.springframework.core.MethodParameter;
@@ -16,11 +14,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
 /*
-* 기능: 응답의 body만 wrapping함.
-* 그 외의 status, header를 건드는건 목적이 아님
-* */
-
-/*
+ * 기능: 응답의 body만 wrapping함.
+ * 그 외의 status, header를 건드는건 목적이 아님
+ * */
 @Order(2)
 @RestControllerAdvice
 public class GlobalResponseWrapper implements ResponseBodyAdvice {
@@ -34,7 +30,6 @@ public class GlobalResponseWrapper implements ResponseBodyAdvice {
     public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
         // body가 이미 CommonResponse
         if (body instanceof CommonResponse) {
-            //여기서 걸려버리는 듯
             return body;
         }
         //swagger 관련은 wrapping 안함
@@ -48,25 +43,7 @@ public class GlobalResponseWrapper implements ResponseBodyAdvice {
         int status = ((ServletServerHttpResponse) response)
                 .getServletResponse()
                 .getStatus();
-
-
-        //ServiceCode serviceCode = (status >= 200 && status < 300) ? ServiceCode.SUCCESS : ServiceCode.NOT_DEFINED_ERROR_FROM_WRAPPER; 세분화 하겠습니다
-
-
-        ServiceCode serviceCode;
-        if (status >= 200 && status < 300) {
-            serviceCode = ServiceCode.SUCCESS;
-        } else if (status == 404) {
-            serviceCode = ServiceCode.NOT_FOUND;
-        } else if (status == 403) {
-            serviceCode = ServiceCode.FORBIDDEN;
-        } else if (status == 401) {
-            serviceCode = ServiceCode.UNAUTHORIZED;
-        } else if (status >= 500) {
-            serviceCode = ServiceCode.INTERNAL_SERVER_ERROR;
-        } else {
-            serviceCode = ServiceCode.NOT_DEFINED_ERROR_FROM_WRAPPER;
-        }
+        ServiceCode serviceCode = (status >= 200 && status < 300) ? ServiceCode.SUCCESS : ServiceCode.NOT_DEFINED_ERROR;
 
 
         // CommonResponse 생성
@@ -74,6 +51,7 @@ public class GlobalResponseWrapper implements ResponseBodyAdvice {
         if (serviceCode.equals(ServiceCode.SUCCESS)) {
             commonResponse = CommonResponse.success(body);
         } else {
+            // TODO: GlobalExceptionHandler 에서 NOT_DEFINED_ERROR도 쳐내도록 해야할듯
             commonResponse = CommonResponse.failure(body);   // 원래 Exception은 여기까지 안옴: 전역예외 핸들러에서 CommonResponse로 변환 되었어야했음.
         }
 
@@ -94,71 +72,3 @@ public class GlobalResponseWrapper implements ResponseBodyAdvice {
     }
 
 }
- */
-
-@Order(2)
-@RestControllerAdvice
-@RequiredArgsConstructor
-public class GlobalResponseWrapper implements ResponseBodyAdvice<Object> {
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
-    @Override
-    public boolean supports(MethodParameter returnType, Class converterType) {
-        return true; // 모든 응답에 적용
-    }
-
-    @Override
-    public Object beforeBodyWrite(Object body, MethodParameter returnType,
-                                  MediaType selectedContentType,
-                                  Class selectedConverterType,
-                                  ServerHttpRequest request,
-                                  ServerHttpResponse response) {
-
-        String path = request.getURI().getPath();
-        if (path.contains("swagger") || path.contains("api-docs") || path.contains("webjars")) {
-            return body;
-        }
-
-        HttpServletResponse servletResponse = ((ServletServerHttpResponse) response).getServletResponse();
-        int status = servletResponse.getStatus();
-        ServiceCode serviceCode = resolveServiceCode(status);
-
-        // 이미 CommonResponse인 경우라도 ServiceCode 갱신
-        if (body instanceof CommonResponse<?> existing) {
-            if (serviceCode == ServiceCode.SUCCESS) {
-                return CommonResponse.success(existing.getData());
-            } else {
-                return CommonResponse.failure(existing.getData(), serviceCode);
-            }
-        }
-
-        CommonResponse<Object> wrappedResponse = (serviceCode == ServiceCode.SUCCESS)
-                ? CommonResponse.success(body)
-                : CommonResponse.failure(body, serviceCode);
-
-        // String 처리
-        if (body instanceof String) {
-            try {
-                return objectMapper.writeValueAsString(wrappedResponse);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException("String response conversion error", e);
-            }
-        }
-
-        return wrappedResponse;
-    }
-
-    private ServiceCode resolveServiceCode(int status) {
-        if (status >= 200 && status < 300) return ServiceCode.SUCCESS;
-        return switch (status) {
-            case 400 -> ServiceCode.BAD_REQUEST;
-            case 401 -> ServiceCode.UNAUTHORIZED;
-            case 403 -> ServiceCode.FORBIDDEN;
-            case 404 -> ServiceCode.NOT_FOUND;
-            case 500 -> ServiceCode.INTERNAL_SERVER_ERROR;
-            default -> ServiceCode.NOT_DEFINED_ERROR_FROM_WRAPPER;
-        };
-    }
-}
-

--- a/src/main/java/org/hanihome/hanihomebe/security/auth/application/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/hanihome/hanihomebe/security/auth/application/filter/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.hanihome.hanihomebe.global.exception.CustomException;
+import org.hanihome.hanihomebe.global.exception.ErrorResponseDTO;
 import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.global.response.dto.CommonResponse;
 import org.hanihome.hanihomebe.security.auth.application.jwt.refresh.RefreshToken;
@@ -137,7 +138,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         response.setContentType("application/json; charset=utf-8");
 
         ObjectMapper objectMapper = new ObjectMapper();
-        CommonResponse<Object> errorResponse = CommonResponse.failure(serviceCode);
+        CommonResponse<Object> errorResponse = CommonResponse.failure(ErrorResponseDTO.of(serviceCode), serviceCode);
+
         response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -32,19 +32,19 @@ spring:
   jackson:
     time-zone: UTC
 
-    mail:
-      host: smtp.gmail.com         # SMTP 서버 호스트
-      port: 587                    # SMTP 포트 (TLS)
-      username: ${SPRING_MAIL_USERNAME}
-      password: ${SPRING_MAIL_PASSWORD}  # Gmail의 경우 앱 비밀번호
-      properties:
-        mail:
-          transport:
-            protocol: smtp
-          smtp:
-            auth: true
-            starttls:
-              enable: true
+  mail:
+    host: smtp.gmail.com         # SMTP 서버 호스트
+    port: 587                    # SMTP 포트 (TLS)
+    username: ${SPRING_MAIL_USERNAME}
+    password: ${SPRING_MAIL_PASSWORD}  # Gmail의 경우 앱 비밀번호
+    properties:
+      mail:
+        transport:
+          protocol: smtp
+        smtp:
+          auth: true
+          starttls:
+            enable: true
   # 응답 인코딩 UTF-8로 고정
   server:
     servlet:


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #150 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
1. 이전 추가 사항 이었던 GlobalResponseWrapper에서 http 상태코드를 ServiceCode에서 반영하던 것은 롤백했습니다
2. Filter에서 ServiceCode를 `ErrorResponseDTO`로 한번 더 감싸서 반환하도록 리팩토링 했습니다

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
