### PR TITLE
[FEAT]#163 매물 suburb 필터링 기능 추가 및 뷰잉옵션아이템 추가

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/item/application/init/ScopeInitializer.java
+++ b/src/main/java/org/hanihome/hanihomebe/item/application/init/ScopeInitializer.java
@@ -125,9 +125,10 @@ public class ScopeInitializer {
     }
 
     private CategoryCode[] getViewingCategories() {
-        return new CategoryCode[] {
-            CategoryCode.VIEWING_CAT1,
-            CategoryCode.VIEWING_CAT2
+        return new CategoryCode[]{
+                CategoryCode.VIEWING_CAT1,
+                CategoryCode.VIEWING_CAT2,
+                CategoryCode.VIEWING_CAT3,
         };
     }
 

--- a/src/main/java/org/hanihome/hanihomebe/item/application/init/ViewingItemInitializer.java
+++ b/src/main/java/org/hanihome/hanihomebe/item/application/init/ViewingItemInitializer.java
@@ -24,7 +24,37 @@ public class ViewingItemInitializer extends OptionItemInitializer {
     }
     /// 취소 이유
     private void initializeCancelReasonItems() {
-        if(super.isAlreadyInitialized(CategoryCode.VIEWING_CAT1)) return;
+        initializeCancelReasonForGuest();
+        initializeCancelReasonForHost();
+
+    }
+
+    private void initializeCancelReasonForHost() {
+        if (super.isAlreadyInitialized(CategoryCode.VIEWING_CAT3)) {
+            return;
+        }
+
+        OptionCategory optionCategory = super.saveCategory(CategoryCode.VIEWING_CAT3);
+
+        List<String> cancelReasons = Arrays.asList(
+                "계약 이미 논의 중이에요",
+                "이미 계약이 완료됐어요",
+                "매물 상태 점검 / 정비 중이에요",
+                "뷰잉 일정 변경을 원해요",
+                "기타"
+        );
+
+        cancelReasons.forEach(reason -> {
+            super.saveItemIfNotExists(optionCategory, reason);
+        });
+
+    }
+
+    private void initializeCancelReasonForGuest() {
+        if (super.isAlreadyInitialized(CategoryCode.VIEWING_CAT1)) {
+
+            return;
+        }
 
         // save category
         OptionCategory optionCategory = super.saveCategory(CategoryCode.VIEWING_CAT1);

--- a/src/main/java/org/hanihome/hanihomebe/item/domain/CategoryCode.java
+++ b/src/main/java/org/hanihome/hanihomebe/item/domain/CategoryCode.java
@@ -14,8 +14,9 @@ public enum CategoryCode {
     PROPERTY_CAT5("부동산 중개 여부를 알려주세요"),
 
     /// 뷰잉 카테고리
-    VIEWING_CAT1("취소 사유를 선택해주세요"),
-    VIEWING_CAT2("뷰잉 체크리스트")
+    VIEWING_CAT1("취소 사유를 선택해주세요_게스트"),
+    VIEWING_CAT2("뷰잉 체크리스트"),
+    VIEWING_CAT3("취소 사유를 선택해주세요_호스트"),
     ;
 
     private final String name;

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/PropertySearchConditionDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/PropertySearchConditionDTO.java
@@ -19,6 +19,8 @@ public class PropertySearchConditionDTO {
     private List<SharePropertySubType> sharePropertySubTypes;        // 아파트, 유닛 등
     private List<RentPropertySubType> rentPropertySubTypes;
 
+    private String suburb;
+
     private BigDecimal minWeeklyCost;
     private BigDecimal maxWeeklyCost;
 //    @JsonSetter(nulls = Nulls.SKIP) => for Jackson

--- a/src/test/java/org/hanihome/hanihomebe/property/application/service/PropertySearchServiceTest.java
+++ b/src/test/java/org/hanihome/hanihomebe/property/application/service/PropertySearchServiceTest.java
@@ -474,6 +474,7 @@ class PropertySearchServiceTest {
         assertEquals(4, results.size());
     }
 
+    /// bill included
     @Test
     void shouldReturnZeroProperty_whenFilterByBillIncluded_false() {
         List<PropertySummaryDTO> results = propertySearchService.search(
@@ -496,6 +497,7 @@ class PropertySearchServiceTest {
         assertEquals(4, results.size());
     }
 
+    /// negotiable
     @Test
     void shouldReturnZeroProperty_whenFilterByNegotiable_false() {
         List<PropertySummaryDTO> results = propertySearchService.search(
@@ -507,6 +509,7 @@ class PropertySearchServiceTest {
         assertTrue(results.isEmpty());
     }
 
+    /// immediate
     @Test
     void shouldReturnZeroProperty_whenFilterByImmediate_false() {
         List<PropertySummaryDTO> results = propertySearchService.search(
@@ -518,6 +521,7 @@ class PropertySearchServiceTest {
         assertTrue(results.isEmpty());
     }
 
+    /// 지하철역 Nkm
     @Test
     void shouldReturnZeroProperty_whenFilterByDistantMetroStop() {
         BigDecimal metroStopLongitude = BigDecimal.valueOf(90.0000);
@@ -583,6 +587,60 @@ class PropertySearchServiceTest {
         List<PropertySummaryDTO> results = propertySearchService.search(
                 PropertySearchConditionDTO.builder()
                         .kinds(List.of(PropertySuperType.SHARE))
+                        .metroStopLongitude(metroStopLongitude)
+                        .metroStopLatitude(metroStopLatitude)
+                        .radiusKm(radiusKm)
+                        .build()
+                , PropertyViewType.SUMMARY);
+
+        logging(results);
+        assertEquals(2, results.size());
+    }
+
+    @Test
+    void shouldReturnFourProperty_whenFilterBySuburb() {
+        List<PropertySummaryDTO> results = propertySearchService.search(
+                PropertySearchConditionDTO.builder()
+                        .suburb("Chatswood")
+                        .build()
+                , PropertyViewType.SUMMARY);
+
+        assertEquals(4, results.size());
+    }
+
+    @Test
+    void shouldReturnFourProperty_whenFilterBySuburb_andLowerCase() {
+        List<PropertySummaryDTO> results = propertySearchService.search(
+                PropertySearchConditionDTO.builder()
+                        .suburb("chatswood")
+                        .build()
+                , PropertyViewType.SUMMARY);
+
+        assertEquals(4, results.size());
+    }
+
+    @Test
+    void shouldReturnZeroProperty_whenFilterBySuburb() {
+        List<PropertySummaryDTO> results = propertySearchService.search(
+                PropertySearchConditionDTO.builder()
+                        .suburb("doowchats")
+                        .build()
+                , PropertyViewType.SUMMARY);
+
+        assertEquals(0, results.size());
+    }
+
+    @Test
+    void shouldReturnTwoProperty_whenFilterByMetroStop_andKinds_andSuburb() {
+        // 경도 1도 : 111.32km
+        BigDecimal metroStopLongitude = BigDecimal.valueOf(1.0000);
+        BigDecimal metroStopLatitude = BigDecimal.valueOf(0.0000);
+        BigDecimal radiusKm = BigDecimal.valueOf(115);
+
+        List<PropertySummaryDTO> results = propertySearchService.search(
+                PropertySearchConditionDTO.builder()
+                        .kinds(List.of(PropertySuperType.SHARE))
+                        .suburb("Chatswood")
                         .metroStopLongitude(metroStopLongitude)
                         .metroStopLatitude(metroStopLatitude)
                         .radiusKm(radiusKm)


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #163
close #165 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
1. 매물 필터링
- 사용자가 설정한 suburb 지역과 일치하는 매물만을 필터링하도록 추가
- suburb 필드에 대한 테스트 코드 작성

2. 뷰잉 옵션 아이템 추가
뷰잉 취소이유에 대한 카테고리를 추가하였다. 게스트 취소사유와 호스트 취소사유가 다름을 확인하여 `VIEWING_CAT3` 카테고리를 추가하였음.

3. 필터링 코드 리팩토링

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
