### PR TITLE
[FEAT]#179 뷰잉 항상 가능 및 호스트의 뷰잉조회 가능 기능 추가

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/deal/application/service/DealService.java
+++ b/src/main/java/org/hanihome/hanihomebe/deal/application/service/DealService.java
@@ -1,6 +1,5 @@
 package org.hanihome.hanihomebe.deal.application.service;
 
-import lombok.RequiredArgsConstructor;
 import org.hanihome.hanihomebe.deal.application.strategy.DealQueryStrategy;
 import org.hanihome.hanihomebe.deal.domain.Deal;
 import org.hanihome.hanihomebe.deal.domain.DealerType;

--- a/src/main/java/org/hanihome/hanihomebe/property/application/time/MeetingDatePeriod.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/time/MeetingDatePeriod.java
@@ -1,0 +1,12 @@
+package org.hanihome.hanihomebe.property.application.time;
+
+import java.time.LocalDate;
+
+public record MeetingDatePeriod(
+        LocalDate meetingDateFrom,
+        LocalDate meetingDateTo
+) {
+    public static MeetingDatePeriod create(LocalDate meetingDateFrom, LocalDate meetingDateTo) {
+        return new MeetingDatePeriod(meetingDateFrom, meetingDateTo);
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/property/application/time/PropertyCreateTimeManager.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/time/PropertyCreateTimeManager.java
@@ -1,0 +1,57 @@
+package org.hanihome.hanihomebe.property.application.time;
+
+import org.hanihome.hanihomebe.global.exception.CustomException;
+import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
+import org.hanihome.hanihomebe.property.application.time.generator.ViewingAvailableDateTimeGenerator;
+import org.hanihome.hanihomebe.property.application.time.validator.TimeSlotValidator;
+import org.hanihome.hanihomebe.property.domain.vo.TimeSlot;
+import org.hanihome.hanihomebe.property.domain.vo.ViewingAvailableDateTime;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+public class PropertyCreateTimeManager {
+    public static List<ViewingAvailableDateTime> validateAndGenerateViewingAvailableDateTimes(List<TimeSlot> timeSlots,
+                                                                                              MeetingDatePeriod meetingDatePeriod) {
+        // 뷰잉 가능 시간 검증
+        validateTimeSlots(timeSlots);
+
+        // ViewingAvailableDateTime 변환
+        List<ViewingAvailableDateTime> generated = generateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
+        return generated;
+    }
+
+
+    public static List<ViewingAvailableDateTime> validateAndGenerateTowMonthsOfViewingAvailableDateTimes(List<TimeSlot> timeSlots) {
+        validateTimeSlots(timeSlots);
+
+        MeetingDatePeriod meetingDatePeriod = buildTwoMonths();
+
+        return generateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
+    }
+
+    private static void validateTimeSlots(List<TimeSlot> timeSlots) {
+        boolean isValidTimeSlots = TimeSlotValidator.validateAllConditions(timeSlots);
+        if(!isValidTimeSlots) {
+            throw new CustomException(ServiceCode.INVALID_PROPERTY_TIME_SLOT);
+        }
+    }
+
+    private static MeetingDatePeriod buildTwoMonths() {
+        LocalDate meetingDateFrom = LocalDateTime
+                .now(ZoneId.of("UTC")).
+                toLocalDate() ;
+        LocalDate meetingDateTo = meetingDateFrom.plusMonths(2);
+        MeetingDatePeriod meetingDatePeriod = MeetingDatePeriod.create(meetingDateFrom, meetingDateTo);
+        return meetingDatePeriod;
+    }
+
+    private static List<ViewingAvailableDateTime> generateViewingAvailableDateTimes(List<TimeSlot> timeSlots, MeetingDatePeriod meetingDatePeriod) {
+        LocalDate meetingDateFrom = meetingDatePeriod.meetingDateFrom();
+        LocalDate meetingDateTo = meetingDatePeriod.meetingDateTo();
+
+        return ViewingAvailableDateTimeGenerator.generate(meetingDateFrom, meetingDateTo, timeSlots);
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/property/application/time/generator/ViewingAvailableDateTimeGenerator.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/time/generator/ViewingAvailableDateTimeGenerator.java
@@ -1,0 +1,42 @@
+package org.hanihome.hanihomebe.property.application.time.generator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hanihome.hanihomebe.property.domain.vo.TimeSlot;
+import org.hanihome.hanihomebe.property.domain.vo.ViewingAvailableDateTime;
+import org.hanihome.hanihomebe.viewing.domain.ViewingTimeInterval;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class ViewingAvailableDateTimeGenerator {
+    public static List<ViewingAvailableDateTime> generate(LocalDate meetingDateFrom, LocalDate meetingDateTo, List<TimeSlot> timeSlots) {
+        LocalDate pos = meetingDateFrom;
+        List<ViewingAvailableDateTime> viewingAvailableDateTimes = new ArrayList<>();
+        while (pos.isBefore(meetingDateTo) || pos.isEqual(meetingDateTo)) {
+            log.info("현재 DTO 생성중의 date:{}", pos.toString() );
+            LocalDate finalTempDate = pos;
+            timeSlots.forEach(timeSlot -> {
+                LocalTime timeFrom = timeSlot.getTimeFrom();
+                LocalTime timeTo = timeSlot.getTimeTo();
+                while(timeFrom.isBefore(timeTo)) {
+                    ViewingAvailableDateTime viewingAvailableDateTime = new ViewingAvailableDateTime(finalTempDate,
+                            timeFrom,
+                            false,
+                            ViewingTimeInterval.MINUTE30);
+                    viewingAvailableDateTimes.add(viewingAvailableDateTime);
+                    timeFrom = timeFrom.plusMinutes(30);
+                }
+            });
+            pos = pos.plusDays(1);
+        }
+        log.info("meetingDateFrom: {}, meetingDateTo: {}", meetingDateFrom, meetingDateTo);
+        log.info("viewingAvailableDateTimes: {}", viewingAvailableDateTimes.stream().map(viewingAvailableDateTime -> viewingAvailableDateTime.getTime()).toList());
+
+        return viewingAvailableDateTimes;
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/property/application/time/validator/TimeSlotValidator.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/time/validator/TimeSlotValidator.java
@@ -1,4 +1,4 @@
-package org.hanihome.hanihomebe.property.application;
+package org.hanihome.hanihomebe.property.application.time.validator;
 
 import org.hanihome.hanihomebe.property.domain.vo.TimeSlot;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/hanihome/hanihomebe/property/domain/Property.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/domain/Property.java
@@ -250,6 +250,8 @@ public abstract class Property {
         if (cmd.getTimeSlots() != null) {
             this.timeSlots = cmd.getTimeSlots();
         }
+        // TODO: ViewingAvailableDateTimes를 업데이트하는 것도 해야함. but 기존 DateTimes와 호환여부를 체크해야함.
+        //  + 호환여부 체크는 별도 계층에서 처리하는게 나아보임
         if (cmd.getViewingAlwaysAvailable() != null) {
             this.viewingAlwaysAvailable = cmd.getViewingAlwaysAvailable();
         }
@@ -258,9 +260,6 @@ public abstract class Property {
         }
         if (cmd.getDisplayStatus() != null) {
             this.displayStatus = cmd.getDisplayStatus();
-        }
-        if (cmd.getViewingAlwaysAvailable() != null) {
-            this.viewingAlwaysAvailable = cmd.getViewingAlwaysAvailable();
         }
     }
 

--- a/src/main/java/org/hanihome/hanihomebe/property/domain/command/RentPropertyPatchCommand.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/domain/command/RentPropertyPatchCommand.java
@@ -3,11 +3,9 @@ package org.hanihome.hanihomebe.property.domain.command;
 import jakarta.validation.constraints.AssertTrue;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
-import org.hanihome.hanihomebe.property.application.TimeSlotValidator;
+import org.hanihome.hanihomebe.property.application.time.validator.TimeSlotValidator;
 import org.hanihome.hanihomebe.property.domain.vo.RentInternalDetails;
 import org.hanihome.hanihomebe.property.domain.enums.CapacityRent;
-import org.hanihome.hanihomebe.property.domain.enums.Exposure;
-import org.hanihome.hanihomebe.property.domain.enums.RealEstateType;
 import org.hanihome.hanihomebe.property.domain.enums.RentPropertySubType;
 
 @Getter

--- a/src/main/java/org/hanihome/hanihomebe/property/domain/command/SharePropertyPatchCommand.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/domain/command/SharePropertyPatchCommand.java
@@ -3,7 +3,7 @@ package org.hanihome.hanihomebe.property.domain.command;
 import jakarta.validation.constraints.AssertTrue;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
-import org.hanihome.hanihomebe.property.application.TimeSlotValidator;
+import org.hanihome.hanihomebe.property.application.time.validator.TimeSlotValidator;
 import org.hanihome.hanihomebe.property.domain.vo.ShareInternalDetails;
 import org.hanihome.hanihomebe.property.domain.enums.CapacityShare;
 import org.hanihome.hanihomebe.property.domain.enums.SharePropertySubType;

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/PropertyCreateRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/PropertyCreateRequestDTO.java
@@ -42,7 +42,6 @@ public sealed interface PropertyCreateRequestDTO permits
 
     LivingConditions livingConditions();
 
-//    Set<LocalDateTime> availableFrom();
     MoveInInfo moveInInfo();
 
     LocalDate meetingDateFrom();

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/RentPropertyCreateRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/RentPropertyCreateRequestDTO.java
@@ -6,13 +6,12 @@ import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.interest.region.Region;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
-import org.hanihome.hanihomebe.property.application.TimeSlotValidator;
+import org.hanihome.hanihomebe.property.application.time.generator.ViewingAvailableDateTimeGenerator;
+import org.hanihome.hanihomebe.property.application.time.validator.TimeSlotValidator;
 import org.hanihome.hanihomebe.property.domain.enums.*;
 import org.hanihome.hanihomebe.property.domain.vo.*;
-import org.hanihome.hanihomebe.viewing.domain.ViewingTimeInterval;
 
 import java.util.ArrayList;
 
@@ -64,28 +63,7 @@ public record RentPropertyCreateRequestDTO(
         }
 
         // ViewingAvailableDateTime 변환
-        LocalDate tempDate = meetingDateFrom;
-        while (tempDate.isBefore(meetingDateTo) || tempDate.isEqual(meetingDateTo)) {
-            log.info("현재 DTO 생성중의 date:{}", tempDate.toString() );
-            LocalDate finalTempDate = tempDate;
-            List<ViewingAvailableDateTime> finalViewingAvailableDateTimes = viewingAvailableDateTimes;
-            timeSlots.forEach(timeSlot -> {
-                LocalTime timeFrom = timeSlot.getTimeFrom();
-                LocalTime timeTo = timeSlot.getTimeTo();
-                while(timeFrom.isBefore(timeTo)) {
-                    ViewingAvailableDateTime viewingAvailableDateTime = new ViewingAvailableDateTime(finalTempDate,
-                            timeFrom,
-                            false,
-                            ViewingTimeInterval.MINUTE30);
-                    finalViewingAvailableDateTimes.add(viewingAvailableDateTime);
-                    timeFrom = timeFrom.plusMinutes(30);
-                }
-            });
-            tempDate = tempDate.plusDays(1);
-        }
-        log.info("meetingDateFrom: {}, meetingDateTo: {}", meetingDateFrom, meetingDateTo);
-        log.info("viewingAvailableDateTimes: {}", viewingAvailableDateTimes.stream().map(viewingAvailableDateTime -> viewingAvailableDateTime.getTime()).toList());
+        viewingAvailableDateTimes = ViewingAvailableDateTimeGenerator.generate(meetingDateFrom, meetingDateTo, timeSlots);
+
     }
-
-
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/RentPropertyCreateRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/RentPropertyCreateRequestDTO.java
@@ -1,15 +1,13 @@
 package org.hanihome.hanihomebe.property.web.dto.request.create;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hanihome.hanihomebe.global.exception.CustomException;
-import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.interest.region.Region;
 
 import java.time.LocalDate;
 import java.util.List;
 
-import org.hanihome.hanihomebe.property.application.time.generator.ViewingAvailableDateTimeGenerator;
-import org.hanihome.hanihomebe.property.application.time.validator.TimeSlotValidator;
+import org.hanihome.hanihomebe.property.application.time.MeetingDatePeriod;
+import org.hanihome.hanihomebe.property.application.time.PropertyCreateTimeManager;
 import org.hanihome.hanihomebe.property.domain.enums.*;
 import org.hanihome.hanihomebe.property.domain.vo.*;
 
@@ -56,14 +54,13 @@ public record RentPropertyCreateRequestDTO(
         if (region.getLatitude() != null && region.getLongitude() != null) {
             validateLatitudeAndLongitude(region.getLatitude(), region.getLongitude());
         }
-        // 뷰잉 가능 시간 검증
-        boolean isValidTimeSlots = TimeSlotValidator.validateAllConditions(timeSlots);
-        if(!isValidTimeSlots) {
-            throw new CustomException(ServiceCode.INVALID_PROPERTY_TIME_SLOT);
+
+        // 타임슬롯 검증, 뷰잉 가능 시간 생성
+        if (viewingAlwaysAvailable) {
+            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateTowMonthsOfViewingAvailableDateTimes(timeSlots);
+        } else {
+            MeetingDatePeriod meetingDatePeriod = MeetingDatePeriod.create(meetingDateFrom, meetingDateTo);
+            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
         }
-
-        // ViewingAvailableDateTime 변환
-        viewingAvailableDateTimes = ViewingAvailableDateTimeGenerator.generate(meetingDateFrom, meetingDateTo, timeSlots);
-
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/SharePropertyCreateRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/SharePropertyCreateRequestDTO.java
@@ -4,13 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.hanihome.hanihomebe.global.exception.CustomException;
 import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.interest.region.Region;
-import org.hanihome.hanihomebe.property.application.TimeSlotValidator;
+import org.hanihome.hanihomebe.property.application.time.generator.ViewingAvailableDateTimeGenerator;
+import org.hanihome.hanihomebe.property.application.time.validator.TimeSlotValidator;
 import org.hanihome.hanihomebe.property.domain.enums.*;
 import org.hanihome.hanihomebe.property.domain.vo.*;
-import org.hanihome.hanihomebe.viewing.domain.ViewingTimeInterval;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,28 +58,6 @@ public record SharePropertyCreateRequestDTO(
         }
 
         // ViewingAvailableDateTime 변환
-        // TODO: 해당 변환을 별도의 클래스에 위임하고 서비스에서 호출하는 것이 나아보임
-        LocalDate tempDate = meetingDateFrom;
-        while (tempDate.isBefore(meetingDateTo) || tempDate.isEqual(meetingDateTo)) {
-            log.info("현재 DTO 생성중의 date:{}", tempDate.toString() );
-            LocalDate finalTempDate = tempDate;
-            List<ViewingAvailableDateTime> finalViewingAvailableDateTimes = viewingAvailableDateTimes;
-            timeSlots.forEach(timeSlot -> {
-                LocalTime timeFrom = timeSlot.getTimeFrom();
-                LocalTime timeTo = timeSlot.getTimeTo();
-                while(timeFrom.isBefore(timeTo)) {
-                    ViewingAvailableDateTime viewingAvailableDateTime = new ViewingAvailableDateTime(finalTempDate,
-                            timeFrom,
-                            false,
-                            ViewingTimeInterval.MINUTE30);
-                    finalViewingAvailableDateTimes.add(viewingAvailableDateTime);
-                    timeFrom = timeFrom.plusMinutes(30);
-                }
-            });
-            tempDate = tempDate.plusDays(1);
-        }
-        log.info("meetingDateFrom: {}, meetingDateTo: {}", meetingDateFrom, meetingDateTo);
-        log.info("viewingAvailableDateTimes: {}", viewingAvailableDateTimes.stream().map(viewingAvailableDateTime -> viewingAvailableDateTime.getTime()).toList());
-
+        viewingAvailableDateTimes = ViewingAvailableDateTimeGenerator.generate(meetingDateFrom, meetingDateTo, timeSlots);
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/SharePropertyCreateRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/SharePropertyCreateRequestDTO.java
@@ -4,6 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.hanihome.hanihomebe.global.exception.CustomException;
 import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.interest.region.Region;
+import org.hanihome.hanihomebe.property.application.time.MeetingDatePeriod;
+import org.hanihome.hanihomebe.property.application.time.PropertyCreateTimeManager;
 import org.hanihome.hanihomebe.property.application.time.generator.ViewingAvailableDateTimeGenerator;
 import org.hanihome.hanihomebe.property.application.time.validator.TimeSlotValidator;
 import org.hanihome.hanihomebe.property.domain.enums.*;
@@ -51,13 +53,12 @@ public record SharePropertyCreateRequestDTO(
             validateLatitudeAndLongitude(region.getLatitude(), region.getLongitude());
         }
 
-        // 뷰잉 가능 시간 검증
-        boolean isValidTimeSlots = TimeSlotValidator.validateAllConditions(timeSlots);
-        if(!isValidTimeSlots) {
-            throw new CustomException(ServiceCode.INVALID_PROPERTY_TIME_SLOT);
+        // 타임슬롯 검증, 뷰잉 가능 시간 생성
+        if (viewingAlwaysAvailable) {
+            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateTowMonthsOfViewingAvailableDateTimes(timeSlots);
+        } else {
+            MeetingDatePeriod meetingDatePeriod = MeetingDatePeriod.create(meetingDateFrom, meetingDateTo);
+            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
         }
-
-        // ViewingAvailableDateTime 변환
-        viewingAvailableDateTimes = ViewingAvailableDateTimeGenerator.generate(meetingDateFrom, meetingDateTo, timeSlots);
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/patch/RentPropertyPatchRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/patch/RentPropertyPatchRequestDTO.java
@@ -2,7 +2,7 @@ package org.hanihome.hanihomebe.property.web.dto.request.patch;
 
 import jakarta.validation.constraints.AssertTrue;
 import lombok.Getter;
-import org.hanihome.hanihomebe.property.application.TimeSlotValidator;
+import org.hanihome.hanihomebe.property.application.time.validator.TimeSlotValidator;
 import org.hanihome.hanihomebe.property.domain.vo.RentInternalDetails;
 import org.hanihome.hanihomebe.property.domain.command.PropertyPatchCommand;
 import org.hanihome.hanihomebe.property.domain.command.RentPropertyPatchCommand;

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/patch/SharePropertyPatchRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/patch/SharePropertyPatchRequestDTO.java
@@ -2,7 +2,7 @@ package org.hanihome.hanihomebe.property.web.dto.request.patch;
 
 import jakarta.validation.constraints.AssertTrue;
 import lombok.Getter;
-import org.hanihome.hanihomebe.property.application.TimeSlotValidator;
+import org.hanihome.hanihomebe.property.application.time.validator.TimeSlotValidator;
 import org.hanihome.hanihomebe.property.domain.vo.ShareInternalDetails;
 import org.hanihome.hanihomebe.property.domain.command.PropertyPatchCommand;
 import org.hanihome.hanihomebe.property.domain.command.SharePropertyPatchCommand;

--- a/src/main/java/org/hanihome/hanihomebe/viewing/application/service/ViewingService.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/application/service/ViewingService.java
@@ -109,8 +109,8 @@ public class ViewingService {
     /**
      * 사용자별 뷰잉 조회
      */
-    public <T> List<T> getViewingByMemberId(Long memberId, ViewingViewType view) {
-        List<Viewing> findViewings = viewingRepository.findByMember_idOrderByMeetingDay(memberId);
+    public <T> List<T> getViewingByMemberId(Long memberId, ViewingStatus status, ViewingViewType view) {
+        List<Viewing> findViewings = viewingRepository.findByMemberAndStatus(memberId, status);
 
         return viewingConversionService.convert(findViewings, view);
     }

--- a/src/main/java/org/hanihome/hanihomebe/viewing/application/service/ViewingService.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/application/service/ViewingService.java
@@ -109,10 +109,15 @@ public class ViewingService {
     /**
      * 사용자별 뷰잉 조회
      */
-    public <T> List<T> getViewingByMemberId(Long memberId, ViewingStatus status, ViewingViewType view) {
-        List<Viewing> findViewings = viewingRepository.findByMemberAndStatus(memberId, status);
+    public <T> List<T> getViewingsByMemberId(Long memberId, ViewingStatus status, ViewingViewType view) {
+        List<Viewing> viewingsAsGuest = viewingRepository.findViewingsAsGuestAndStatus(memberId, status);
+        List<Viewing> viewingsAsHost = viewingRepository.findViewingsAsHostAndStatus(memberId, status);
 
-        return viewingConversionService.convert(findViewings, view);
+        List<Viewing> all = new ArrayList<>(viewingsAsGuest);
+        all.addAll(viewingsAsHost);
+
+        Collections.sort(all, Comparator.comparing(Viewing::getMeetingDay));
+        return viewingConversionService.convert(all, view);
     }
 
     public ViewingResponseDTO getViewingById(Long viewingId) {
@@ -307,9 +312,13 @@ public class ViewingService {
      * @return 조회된 뷰잉들의 시간
      */
     public Map<LocalDate, List<LocalTime>> getMyViewingDatesByStatus(Long memberId, ViewingStatus status) {
-        List<Viewing> myViewingsByStatus = viewingRepository.findByMemberIdAndStatus(memberId, status);
+        List<Viewing> viewingsAsGuestAndStatus = viewingRepository.findViewingsAsGuestAndStatus(memberId, status);
+        List<Viewing> viewingsAsHostAndStatus = viewingRepository.findViewingsAsHostAndStatus(memberId, status);
 
-        Map<LocalDate, List<LocalTime>> response = myViewingsByStatus.stream()
+        List<Viewing> all = new ArrayList<>(viewingsAsGuestAndStatus);
+        all.addAll(viewingsAsHostAndStatus);
+
+        Map<LocalDate, List<LocalTime>> response = all.stream()
                 .collect(Collectors.groupingBy(viewing -> viewing.getMeetingDay().toLocalDate(),
                         TreeMap::new,
                         Collectors.mapping(viewing -> viewing.getMeetingDay().toLocalTime(), Collectors.toList())));

--- a/src/main/java/org/hanihome/hanihomebe/viewing/domain/Viewing.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/domain/Viewing.java
@@ -4,7 +4,6 @@ import lombok.*;
 import org.hanihome.hanihomebe.global.BaseEntity;
 import org.hanihome.hanihomebe.member.domain.Member;
 import org.hanihome.hanihomebe.property.domain.Property;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/main/java/org/hanihome/hanihomebe/viewing/repository/ViewingRepository.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/repository/ViewingRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
 import java.util.List;
 import java.time.LocalDateTime;
 
@@ -23,8 +22,6 @@ public interface ViewingRepository extends JpaRepository<Viewing, Long> {
      */
     List<Viewing> findByMemberAndMeetingDayAfterAndStatus(Member member, LocalDateTime meetingDayAfter, ViewingStatus status);
 
-    List<Viewing> findByMemberIdAndStatus(Long memberId, ViewingStatus status);
-
     List<Viewing> findByProperty_IdAndStatus(Long propertyId, ViewingStatus status);
 
     List<Viewing> findByProperty_Id(Long propertyId);
@@ -32,7 +29,12 @@ public interface ViewingRepository extends JpaRepository<Viewing, Long> {
     @Query("select v from Viewing v " +
             "where v.member.id = :memberId " +
             "and (:status is null or :status = v.status)")
-    List<Viewing> findByMemberAndStatus(@Param("memberId") Long memberId,
-                                        @Param("status") ViewingStatus status);
+    List<Viewing> findViewingsAsGuestAndStatus(@Param("memberId") Long memberId,
+                                               @Param("status") ViewingStatus status);
+
+    @Query("select v from Viewing  v " +
+            "where v.property.member.id = :memberId " +
+            "and (:status is null or :status = v.status)")
+    List<Viewing> findViewingsAsHostAndStatus(Long memberId, ViewingStatus status);
 
 }

--- a/src/main/java/org/hanihome/hanihomebe/viewing/repository/ViewingRepository.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/repository/ViewingRepository.java
@@ -4,6 +4,8 @@ import org.hanihome.hanihomebe.member.domain.Member;
 import org.hanihome.hanihomebe.viewing.domain.Viewing;
 import org.hanihome.hanihomebe.viewing.domain.ViewingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
@@ -21,11 +23,16 @@ public interface ViewingRepository extends JpaRepository<Viewing, Long> {
      */
     List<Viewing> findByMemberAndMeetingDayAfterAndStatus(Member member, LocalDateTime meetingDayAfter, ViewingStatus status);
 
-    List<Viewing> findByMember_idOrderByMeetingDay(Long memberId);
-
     List<Viewing> findByMemberIdAndStatus(Long memberId, ViewingStatus status);
 
     List<Viewing> findByProperty_IdAndStatus(Long propertyId, ViewingStatus status);
 
     List<Viewing> findByProperty_Id(Long propertyId);
+
+    @Query("select v from Viewing v " +
+            "where v.member.id = :memberId " +
+            "and (:status is null or :status = v.status)")
+    List<Viewing> findByMemberAndStatus(@Param("memberId") Long memberId,
+                                        @Param("status") ViewingStatus status);
+
 }

--- a/src/main/java/org/hanihome/hanihomebe/viewing/web/controller/ViewingController.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/web/controller/ViewingController.java
@@ -1,7 +1,6 @@
 package org.hanihome.hanihomebe.viewing.web.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.hanihome.hanihomebe.notification.application.service.*;
 import org.hanihome.hanihomebe.viewing.web.dto.ViewingBelongsToPropertyDTO;
 import org.hanihome.hanihomebe.security.auth.user.detail.CustomUserDetails;
 import org.hanihome.hanihomebe.viewing.application.service.ViewingNotificationService;
@@ -53,8 +52,8 @@ public class ViewingController {
 
     // 내 뷰잉 조회
     @GetMapping("/viewings/my-viewings")
-    public ResponseEntity<List<? extends ViewingDTOByView>> getUserViewings(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                            @RequestParam(required = false) ViewingViewType view) {
+    public ResponseEntity<List<? extends ViewingDTOByView>> getViewingsByMember(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                @RequestParam(required = false) ViewingViewType view) {
         List<? extends ViewingDTOByView> viewings = viewingService.getViewingByMemberId(userDetails.getUserId(), view);
         return ResponseEntity.ok(viewings);
     }
@@ -75,7 +74,7 @@ public class ViewingController {
 
     //매물에 속한 뷰잉 정보 조회
     @GetMapping("/properties/{propertyId}/viewings")
-    public List<ViewingBelongsToPropertyDTO> getViewingsBelongsToProperty(@RequestParam Long propertyId,
+    public List<ViewingBelongsToPropertyDTO> getViewingsBelongsToProperty(@PathVariable Long propertyId,
                                                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
         return viewingService.getViewingsBelongsToProperty(userDetails.getUserId(), propertyId);
     }

--- a/src/main/java/org/hanihome/hanihomebe/viewing/web/controller/ViewingController.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/web/controller/ViewingController.java
@@ -53,8 +53,10 @@ public class ViewingController {
     // 내 뷰잉 조회
     @GetMapping("/viewings/my-viewings")
     public ResponseEntity<List<? extends ViewingDTOByView>> getViewingsByMember(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                                @RequestParam(required = false) ViewingViewType view) {
-        List<? extends ViewingDTOByView> viewings = viewingService.getViewingByMemberId(userDetails.getUserId(), view);
+                                                                                @RequestParam(required = false) ViewingStatus status,
+                                                                                @RequestParam(required = false) ViewingViewType view
+                                                                                ) {
+        List<? extends ViewingDTOByView> viewings = viewingService.getViewingByMemberId(userDetails.getUserId(), status, view);
         return ResponseEntity.ok(viewings);
     }
 

--- a/src/main/java/org/hanihome/hanihomebe/viewing/web/controller/ViewingController.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/web/controller/ViewingController.java
@@ -52,11 +52,11 @@ public class ViewingController {
 
     // 내 뷰잉 조회
     @GetMapping("/viewings/my-viewings")
-    public ResponseEntity<List<? extends ViewingDTOByView>> getViewingsByMember(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                                @RequestParam(required = false) ViewingStatus status,
-                                                                                @RequestParam(required = false) ViewingViewType view
+    public ResponseEntity<List<? extends ViewingDTOByView>> getMyViewings(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                          @RequestParam(required = false) ViewingStatus status,
+                                                                          @RequestParam(required = false) ViewingViewType view
                                                                                 ) {
-        List<? extends ViewingDTOByView> viewings = viewingService.getViewingByMemberId(userDetails.getUserId(), status, view);
+        List<? extends ViewingDTOByView> viewings = viewingService.getViewingsByMemberId(userDetails.getUserId(), status, view);
         return ResponseEntity.ok(viewings);
     }
 


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #178 
close #179 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
[추가된 기능]
1. 호스트의 뷰잉 조회
기존: 게스트로서 연관된 뷰잉만을 조회하였음
변경: 실제 서비스 요구에 맞게 호스트 역시나 게스트에 의해 만들어진 뷰잉을 조회할 수 있어야함

2. 매물 등록 - 뷰잉 항상 가능
기존: 항상 가능 여부만을 데이터로 저장하고 실제 로직은 없었음
변경: 항상 가능하다고 체크할 시에 현재일로부터 2달간 모든 시간대를 뷰잉 가능하도록 설정한다.

[리팩토링]
뷰잉 가능시각을 등록할 때 DTO 내부에서 타임슬롯의 유효성을 검증하고 새로운 `ViewingAvailableDateTime`을 생성했음.
이제는 뷰잉 타임슬롯 검증과 엔티티 생성을 `PropertyCreateTimeManager`에서 처리하도록 응집도를 높였다.


## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
