### PR TITLE
[FEAT]#181 현재 사용자가 매물 소유자 or not, 즐겨찾기함 or not 확인 기능추가

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/global/response/domain/ServiceCode.java
+++ b/src/main/java/org/hanihome/hanihomebe/global/response/domain/ServiceCode.java
@@ -108,6 +108,9 @@ public enum ServiceCode {
     NOT_DEFINED_ERROR_FROM_WRAPPER(HttpStatus.BAD_REQUEST, "정의 되지 않은 에러입니다 from Wrapper"),
     NOT_DEFINED_ERROR_FROM_FILTER(HttpStatus.BAD_REQUEST, "정의 되지 않은 에러입니다 from 필터"),
     NOT_DEFINED_ERROR(HttpStatus.BAD_REQUEST, "정의 되지 않은 에러입니다"),
+
+    // security 인증/인가
+    NEED_TO_AUTHENTICATED(HttpStatus.INTERNAL_SERVER_ERROR, "해당 요청은 인증이 필요합니다. 하지만 로그인되지 않은 사용자가 필터를 통과했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/hanihome/hanihomebe/global/utility/SecurityContextUtils.java
+++ b/src/main/java/org/hanihome/hanihomebe/global/utility/SecurityContextUtils.java
@@ -1,0 +1,19 @@
+package org.hanihome.hanihomebe.global.utility;
+
+import org.hanihome.hanihomebe.security.auth.user.detail.CustomUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+public class SecurityContextUtils {
+
+    public static Optional<Long> getHttpRequesterId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null) {
+            return Optional.empty();
+        }
+        CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
+        return Optional.of(userDetails.getUserId());
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/member/domain/Member.java
+++ b/src/main/java/org/hanihome/hanihomebe/member/domain/Member.java
@@ -66,6 +66,7 @@ public class Member extends BaseEntity {
     @Column(name = "profile_image", length = 1000)
     private String profileImage;
 
+    @Builder.Default // 테스트 코드 오류때문에 일단 추가합니다
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Verification> verifications = new ArrayList<>();
 

--- a/src/main/java/org/hanihome/hanihomebe/member/web/dto/MemberSummaryDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/member/web/dto/MemberSummaryDTO.java
@@ -1,0 +1,24 @@
+package org.hanihome.hanihomebe.member.web.dto;
+
+import org.hanihome.hanihomebe.member.domain.Member;
+import org.hanihome.hanihomebe.verification.domain.VerificationStatus;
+
+public record MemberSummaryDTO(
+        Long id,
+        String profileImage,
+        String nickname,
+        Boolean verified
+) {
+    public static MemberSummaryDTO from(Member member) {
+        boolean isVerified = member.getVerifications()
+                .stream()
+                .anyMatch(v -> v.getStatus() == VerificationStatus.APPROVED);
+
+        return new MemberSummaryDTO(
+                member.getId(),
+                member.getProfileImage(),
+                member.getNickname(),
+                isVerified
+        );
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/property/application/converter/PropertyConvertContext.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/converter/PropertyConvertContext.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.hanihome.hanihomebe.item.web.dto.OptionItemResponseDTO;
+import org.hanihome.hanihomebe.member.web.dto.MemberSummaryDTO;
 import org.hanihome.hanihomebe.metro.web.dto.nearest.NearestMetroStopResponseDTO;
 import org.hanihome.hanihomebe.property.domain.Property;
+import org.hanihome.hanihomebe.property.web.dto.response.summary.MetaInfo;
 
 import java.util.List;
 
@@ -17,12 +19,21 @@ public class PropertyConvertContext {
     private Property property;
     private List<OptionItemResponseDTO> optionItems;
     private NearestMetroStopResponseDTO nearestMetroStopResponseDTO;
+    private MemberSummaryDTO hostSummaryDTO;
+    private MetaInfo metaInfo;
 
-    public static PropertyConvertContext create(Property property, List<OptionItemResponseDTO> optionItems, NearestMetroStopResponseDTO nearestMetroStopResponseDTO) {
+    public static PropertyConvertContext create(Property property,
+                                                List<OptionItemResponseDTO> optionItems,
+                                                NearestMetroStopResponseDTO nearestMetroStopResponseDTO,
+                                                MemberSummaryDTO hostSummaryDTO,
+                                                MetaInfo metaInfo
+    ) {
         return PropertyConvertContext.builder()
                 .property(property)
                 .optionItems(optionItems)
                 .nearestMetroStopResponseDTO(nearestMetroStopResponseDTO)
+                .hostSummaryDTO(hostSummaryDTO)
+                .metaInfo(metaInfo)
                 .build();
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/application/converter/PropertyDefaultConverter.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/converter/PropertyDefaultConverter.java
@@ -4,12 +4,15 @@ package org.hanihome.hanihomebe.property.application.converter;
 import org.hanihome.hanihomebe.global.exception.CustomException;
 import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.item.web.dto.OptionItemResponseDTO;
+import org.hanihome.hanihomebe.member.web.dto.MemberSummaryDTO;
 import org.hanihome.hanihomebe.property.domain.Property;
 import org.hanihome.hanihomebe.property.domain.RentProperty;
 import org.hanihome.hanihomebe.property.domain.ShareProperty;
 import org.hanihome.hanihomebe.property.domain.enums.PropertySuperType;
 import org.hanihome.hanihomebe.property.web.dto.enums.PropertyViewType;
-import org.hanihome.hanihomebe.property.web.dto.response.basic.PropertyResponseDTO;
+import org.hanihome.hanihomebe.property.web.dto.response.PropertyWithMemberResponseDTO;
+import org.hanihome.hanihomebe.property.web.dto.response.RentPropertyWithMemberResponseDTO;
+import org.hanihome.hanihomebe.property.web.dto.response.SharePropertyWithMemberResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.basic.RentPropertyResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.basic.SharePropertyResponseDTO;
 import org.hibernate.Hibernate;
@@ -19,28 +22,35 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class PropertyDefaultConverter implements PropertyConverter<PropertyResponseDTO> {
+public class PropertyDefaultConverter implements PropertyConverter<PropertyWithMemberResponseDTO> {
     @Override
     public PropertyViewType supports() {
         return PropertyViewType.DEFAULT;
     }
 
     @Override
-    public PropertyResponseDTO convert(PropertyConvertContext propertyConvertContext) {
-        return toResponseDTO(propertyConvertContext.getProperty(), propertyConvertContext.getOptionItems());
+    public PropertyWithMemberResponseDTO convert(PropertyConvertContext propertyConvertContext) {
+        return toResponseDTO(propertyConvertContext.getProperty(), propertyConvertContext);
     }
 
 
-    PropertyResponseDTO toResponseDTO(Property entity, List<OptionItemResponseDTO> optionItems) {
+    PropertyWithMemberResponseDTO toResponseDTO(Property entity, PropertyConvertContext context) {
+        List<OptionItemResponseDTO> optionItems = context.getOptionItems();
+        MemberSummaryDTO memberSummary = context.getHostSummaryDTO();
         PropertySuperType propertyType = entity.getKind();
         switch (propertyType) {
             case SHARE:
-                return SharePropertyResponseDTO.from(safeCast(entity, ShareProperty.class), optionItems);
+                return SharePropertyWithMemberResponseDTO.from(SharePropertyResponseDTO.from(safeCast(entity, ShareProperty.class), optionItems),
+                        memberSummary,
+                        context.getMetaInfo());
             case RENT:
-                return RentPropertyResponseDTO.from(safeCast(entity, RentProperty.class), optionItems);
+                return RentPropertyWithMemberResponseDTO.from(RentPropertyResponseDTO.from(safeCast(entity, RentProperty.class), optionItems),
+                        memberSummary,
+                        context.getMetaInfo());
             default:
                 throw new CustomException(ServiceCode.INVALID_PROPERTY_TYPE);
         }
+
     }
 
     private <T> T safeCast(Object entity, Class<T> targetClass) {
@@ -48,6 +58,5 @@ public class PropertyDefaultConverter implements PropertyConverter<PropertyRespo
             return targetClass.cast(Hibernate.unproxy(entity));
         }
         return targetClass.cast(entity);
-
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/application/converter/PropertySummaryConverter.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/converter/PropertySummaryConverter.java
@@ -8,6 +8,7 @@ import org.hanihome.hanihomebe.property.domain.RentProperty;
 import org.hanihome.hanihomebe.property.domain.ShareProperty;
 import org.hanihome.hanihomebe.property.domain.enums.PropertySuperType;
 import org.hanihome.hanihomebe.property.web.dto.enums.PropertyViewType;
+import org.hanihome.hanihomebe.property.web.dto.response.summary.MetaInfo;
 import org.hanihome.hanihomebe.property.web.dto.response.summary.PropertySummaryDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.summary.RentPropertySummaryDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.summary.SharePropertySummaryDTO;
@@ -24,16 +25,25 @@ public class PropertySummaryConverter implements PropertyConverter<PropertySumma
 
     @Override
     public PropertySummaryDTO convert(PropertyConvertContext propertyConvertContext) {
-        return toSummaryDTO(propertyConvertContext.getProperty(), propertyConvertContext.getNearestMetroStopResponseDTO());
+        return toSummaryDTO(propertyConvertContext.getProperty(),
+                propertyConvertContext.getNearestMetroStopResponseDTO(),
+                propertyConvertContext.getMetaInfo()
+        );
     }
 
-    PropertySummaryDTO toSummaryDTO(Property entity, NearestMetroStopResponseDTO nearestMetroStopResponseDTO) {
+    PropertySummaryDTO toSummaryDTO(Property entity,
+                                    NearestMetroStopResponseDTO nearestMetroStopResponseDTO,
+                                    MetaInfo metaInfo) {
         PropertySuperType propertyType = entity.getKind();
         switch (propertyType) {
             case SHARE:
-                return SharePropertySummaryDTO.from(safeCast(entity, ShareProperty.class), nearestMetroStopResponseDTO);
+                return SharePropertySummaryDTO.from(safeCast(entity, ShareProperty.class),
+                        nearestMetroStopResponseDTO,
+                        metaInfo);
             case RENT:
-                return RentPropertySummaryDTO.from(safeCast(entity, RentProperty.class), nearestMetroStopResponseDTO);
+                return RentPropertySummaryDTO.from(safeCast(entity, RentProperty.class),
+                        nearestMetroStopResponseDTO,
+                        metaInfo);
             default:
                 throw new CustomException(ServiceCode.INVALID_PROPERTY_TYPE);
         }

--- a/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyConversionService.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyConversionService.java
@@ -1,9 +1,14 @@
 package org.hanihome.hanihomebe.property.application.service;// PropertyConversionService.java (이전 답변에서 제공된 코드)
 
+import io.opencensus.stats.Measure;
 import org.hanihome.hanihomebe.global.exception.CustomException;
 import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
+import org.hanihome.hanihomebe.global.utility.SecurityContextUtils;
 import org.hanihome.hanihomebe.item.application.converter.OptionItemConverterForProperty;
 import org.hanihome.hanihomebe.item.web.dto.OptionItemResponseDTO;
+import org.hanihome.hanihomebe.member.domain.Member;
+import org.hanihome.hanihomebe.member.repository.MemberRepository;
+import org.hanihome.hanihomebe.member.web.dto.MemberSummaryDTO;
 import org.hanihome.hanihomebe.metro.domain.NearestMetroStop;
 import org.hanihome.hanihomebe.metro.repository.NearestMetroStopRepository;
 import org.hanihome.hanihomebe.metro.web.dto.nearest.NearestMetroStopResponseDTO;
@@ -11,28 +16,39 @@ import org.hanihome.hanihomebe.property.application.converter.PropertyConvertCon
 import org.hanihome.hanihomebe.property.application.converter.PropertyConverter;
 import org.hanihome.hanihomebe.property.domain.Property;
 import org.hanihome.hanihomebe.property.web.dto.enums.PropertyViewType;
+import org.hanihome.hanihomebe.property.web.dto.response.summary.MetaInfo;
+import org.hanihome.hanihomebe.wishlist.domain.WishItem;
+import org.hanihome.hanihomebe.wishlist.domain.enums.WishTargetType;
+import org.hanihome.hanihomebe.wishlist.repository.WishItemRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Transactional(readOnly = true)
 @Service
 public class PropertyConversionService {
 
     private final Map<PropertyViewType, PropertyConverter<?>> propertyConverterMap;
     private final NearestMetroStopRepository nearestMetroStopRepository;
     private final OptionItemConverterForProperty optionItemConverter;
+    private final MemberRepository memberRepository;
+    private final WishItemRepository wishItemRepository;
 
     public PropertyConversionService(List<PropertyConverter<?>> converterList,
                                      NearestMetroStopRepository nearestMetroStopRepository,
-                                     OptionItemConverterForProperty optionItemConverter
+                                     OptionItemConverterForProperty optionItemConverter,
+                                     MemberRepository memberRepository,
+                                     WishItemRepository wishItemRepository
     ) {
         this.propertyConverterMap = converterList.stream()
                 .collect(Collectors.toMap(PropertyConverter::supports, Function.identity()));
         this.nearestMetroStopRepository = nearestMetroStopRepository;
         this.optionItemConverter = optionItemConverter;
+        this.memberRepository = memberRepository;
+        this.wishItemRepository = wishItemRepository;
     }
 
 
@@ -41,12 +57,44 @@ public class PropertyConversionService {
     }
 
     public <T> T convertProperty(Property property, PropertyViewType viewType) {
+
         PropertyConverter<T> converter = getConverterByView(viewType);
-
         NearestMetroStop nearestMetroStop = getNearestMetroStop(property);
+        Member host = property.getMember();
 
-        return converter.convert(preparePropertyConvertContext(property, nearestMetroStop));
+        MetaInfo metaInfo = buildMetaInfoForProperty(property, host);
+        return converter.convert(buildPropertyConvertContext(property, nearestMetroStop, MemberSummaryDTO.from(host), metaInfo));
     }
+
+    private MetaInfo buildMetaInfoForProperty(Property property, Member host) {
+        MetaInfo metaInfo;
+        Optional<Long> optRequesterId = SecurityContextUtils.getHttpRequesterId();
+        if (optRequesterId.isEmpty()) {
+            metaInfo = MetaInfo.create(false, false);
+        } else {
+            Long requesterId = optRequesterId.get();
+            boolean isOwner = requesterId.equals(host.getId());
+            boolean isWished = isWished(property, requesterId);
+
+            metaInfo = MetaInfo.create(isOwner, isWished);
+        }
+        return metaInfo;
+    }
+
+    private boolean isWished(Property property, Long requesterId) {
+        Member requester = memberRepository.findById(requesterId)
+                .orElseThrow(() -> new CustomException(ServiceCode.MEMBER_NOT_EXISTS));
+
+        List<WishItem> propertyWishes = wishItemRepository.findByMemberAndTargetType(
+                requester, WishTargetType.PROPERTY
+        );
+
+        List<Long> propertyIds = propertyWishes.stream()
+                .map(WishItem::getTargetId)
+                .toList();
+        return propertyIds.contains(property.getId());
+    }
+
 
     private <T> PropertyConverter<T> getConverterByView(PropertyViewType view) {
         PropertyConverter<?> converter = propertyConverterMap.getOrDefault(view, propertyConverterMap.get(PropertyViewType.DEFAULT));
@@ -58,15 +106,72 @@ public class PropertyConversionService {
                 .orElseThrow(() -> new CustomException(ServiceCode.NEAREST_METRO_STOP_NOT_EXISTS));
     }
 
-    private <T> List<T> convertPropertyListToDTO(List<Property> properties, PropertyViewType viewType) {
-        return properties
-                .stream()
-                .map(property -> this.<T>convertProperty(property, viewType))
+    private <T> List<T> convertPropertyListToDTO(
+            List<Property> properties,
+            PropertyViewType viewType
+    ) {
+        Optional<Long> optRequesterId = SecurityContextUtils.getHttpRequesterId();
+
+        List<WishItem> wishItems = getWishItems(optRequesterId);
+
+        Set<Long> wishedPropertyIds = wishItems.stream()
+                .map(WishItem::getTargetId)
+                .collect(Collectors.toSet());
+
+        PropertyConverter<T> converter = getConverterByView(viewType);
+
+        return properties.stream()
+                .map(property -> {
+                    NearestMetroStop nearestMetroStop = getNearestMetroStop(property);
+                    Member host = property.getMember();
+
+                    boolean isOwner = optRequesterId
+                            .map(id -> id.equals(host.getId()))
+                            .orElse(false);
+
+                    boolean isWished = optRequesterId
+                            .map(id -> wishedPropertyIds.contains(property.getId()))
+                            .orElse(false);
+
+                    MetaInfo metaInfo = new MetaInfo(isOwner, isWished);
+
+                    PropertyConvertContext context = buildPropertyConvertContext(
+                            property,
+                            nearestMetroStop,
+                            MemberSummaryDTO.from(host),
+                            metaInfo
+                    );
+                    return converter.convert(context);
+                })
                 .collect(Collectors.toList());
     }
 
-    private PropertyConvertContext preparePropertyConvertContext(Property property, NearestMetroStop nearestMetroStop) {
-        return PropertyConvertContext.create(property, getOptionItemResponseDTOS(property), NearestMetroStopResponseDTO.from(nearestMetroStop));
+    private List<WishItem> getWishItems(Optional<Long> optRequesterId) {
+        List<WishItem> wishItems;
+        if (optRequesterId.isPresent()) {
+            Long requesterId = optRequesterId.get();
+            Member requester = memberRepository.findById(requesterId)
+                    .orElseThrow(() -> new CustomException(ServiceCode.MEMBER_NOT_EXISTS));
+            wishItems = wishItemRepository.findByMemberAndTargetType(
+                    requester, WishTargetType.PROPERTY);
+            return wishItems;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private PropertyConvertContext buildPropertyConvertContext(Property property,
+                                                               NearestMetroStop nearestMetroStop,
+                                                               MemberSummaryDTO memberSummaryDTO,
+                                                               MetaInfo metaInfo
+    ) {
+        return PropertyConvertContext.create(
+                property,
+                getOptionItemResponseDTOS(property),
+                NearestMetroStopResponseDTO.from(nearestMetroStop),
+                memberSummaryDTO,
+                metaInfo
+        );
     }
 
     private List<OptionItemResponseDTO> getOptionItemResponseDTOS(Property property) {

--- a/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyService.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyService.java
@@ -21,6 +21,7 @@ import org.hanihome.hanihomebe.property.web.dto.enums.PropertyViewType;
 import org.hanihome.hanihomebe.property.web.dto.request.PropertyCompleteTradeDTO;
 import org.hanihome.hanihomebe.property.web.dto.request.create.PropertyCreateRequestDTO;
 import org.hanihome.hanihomebe.property.web.dto.request.patch.PropertyPatchRequestDTO;
+import org.hanihome.hanihomebe.property.web.dto.response.PropertyWithMemberResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.basic.PropertyResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.TimeWithReserved;
 import org.hanihome.hanihomebe.security.auth.user.detail.CustomUserDetails;
@@ -53,7 +54,7 @@ public class PropertyService {
 
     /// create
     @Transactional
-    public PropertyResponseDTO createProperty(PropertyCreateRequestDTO dto){
+    public PropertyWithMemberResponseDTO createProperty(PropertyCreateRequestDTO dto){
         log.info("property 생성 로직 진입");
 
         Member findMember = memberRepository.findById(dto.memberId()).orElseThrow(() -> new CustomException(ServiceCode.MEMBER_NOT_EXISTS));
@@ -98,7 +99,7 @@ public class PropertyService {
     /**
      * 단일 Property 조회 (부모 타입으로 조회)
      */
-    public PropertyResponseDTO getPropertyById(Long id) {
+    public PropertyWithMemberResponseDTO getPropertyById(Long id) {
         Property findProperty = propertyRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ServiceCode.PROPERTY_NOT_EXISTS));
 
@@ -178,7 +179,7 @@ public class PropertyService {
     /// update
 
     @Transactional
-    public PropertyResponseDTO patch(Long propertyId, PropertyPatchRequestDTO dto) {
+    public PropertyWithMemberResponseDTO patch(Long propertyId, PropertyPatchRequestDTO dto) {
         Property findProperty = propertyRepository.findById(propertyId).orElseThrow(() -> new RuntimeException("Property not found: " + propertyId));
         List<PropertyOptionItem> propertyOptionItems = dto.getOptionItemIds() == null ? null
                 : createPropertyOptionItems(dto, findProperty);

--- a/src/main/java/org/hanihome/hanihomebe/property/web/controller/PropertyController.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/controller/PropertyController.java
@@ -10,6 +10,7 @@ import org.hanihome.hanihomebe.property.web.dto.enums.PropertyViewType;
 import org.hanihome.hanihomebe.property.web.dto.request.PropertyCompleteTradeDTO;
 import org.hanihome.hanihomebe.property.web.dto.request.create.PropertyCreateRequestDTO;
 import org.hanihome.hanihomebe.property.web.dto.request.patch.PropertyPatchRequestDTO;
+import org.hanihome.hanihomebe.property.web.dto.response.PropertyWithMemberResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.basic.PropertyResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.TimeWithReserved;
 import org.hanihome.hanihomebe.security.auth.user.detail.CustomUserDetails;
@@ -30,7 +31,7 @@ public class PropertyController {
 
     //create
     @PostMapping("/properties")
-    public PropertyResponseDTO createProperty(@RequestBody @Valid PropertyCreateRequestDTO dto) {
+    public PropertyWithMemberResponseDTO createProperty(@RequestBody @Valid PropertyCreateRequestDTO dto) {
         return propertyService.createProperty(dto);
     }
 
@@ -44,7 +45,7 @@ public class PropertyController {
     }
 
     @GetMapping("/properties/{propertyId}")
-    public PropertyResponseDTO getPropertyById(@PathVariable Long propertyId) {
+    public PropertyWithMemberResponseDTO getPropertyById(@PathVariable Long propertyId) {
         return propertyService.getPropertyById(propertyId);
     }
 
@@ -94,7 +95,7 @@ public class PropertyController {
     }
 */
     @PatchMapping("/properties/{propertyId}")
-    public PropertyResponseDTO patch(@PathVariable("propertyId") Long propertyId,
+    public PropertyWithMemberResponseDTO patch(@PathVariable("propertyId") Long propertyId,
                                      @RequestBody @Valid PropertyPatchRequestDTO dto) throws JsonPatchException, IOException {
         return propertyService.patch(propertyId, dto);
     }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/PropertyWithMemberResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/PropertyWithMemberResponseDTO.java
@@ -1,0 +1,52 @@
+package org.hanihome.hanihomebe.property.web.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.hanihome.hanihomebe.interest.region.Region;
+import org.hanihome.hanihomebe.item.web.dto.OptionItemResponseDTO;
+import org.hanihome.hanihomebe.member.web.dto.MemberSummaryDTO;
+import org.hanihome.hanihomebe.property.domain.enums.DisplayStatus;
+import org.hanihome.hanihomebe.property.domain.enums.GenderPreference;
+import org.hanihome.hanihomebe.property.domain.enums.PropertySuperType;
+import org.hanihome.hanihomebe.property.domain.enums.TradeStatus;
+import org.hanihome.hanihomebe.property.domain.vo.CostDetails;
+import org.hanihome.hanihomebe.property.domain.vo.LivingConditions;
+import org.hanihome.hanihomebe.property.domain.vo.MoveInInfo;
+import org.hanihome.hanihomebe.property.web.dto.response.basic.RentPropertyResponseDTO;
+import org.hanihome.hanihomebe.property.web.dto.response.basic.SharePropertyResponseDTO;
+import org.hanihome.hanihomebe.property.web.dto.response.summary.MetaInfo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property="type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = SharePropertyResponseDTO.class, name = "SHARE"),
+        @JsonSubTypes.Type(value = RentPropertyResponseDTO.class, name = "RENT")
+})
+public sealed interface PropertyWithMemberResponseDTO extends PropertyDTOByView
+        permits SharePropertyWithMemberResponseDTO, RentPropertyWithMemberResponseDTO {
+
+    Long id();
+    int wishCount();
+    LocalDateTime createdAt();
+    LocalDateTime lastModifiedAt();
+    Long memberId();
+    List<OptionItemResponseDTO> optionItems();
+    DisplayStatus displayStatus();
+    TradeStatus tradeStatus();
+    PropertySuperType kind();
+    GenderPreference genderPreference();
+    boolean lgbtAvailable();
+    Region region();
+    List<String> photoUrls();
+    String thumbnailUrl();
+    CostDetails costDetails();
+    LivingConditions livingConditions();
+    MoveInInfo moveInInfo();
+    String description();
+    MemberSummaryDTO hostSummary();
+    MetaInfo metaInfo();
+}

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/RentPropertyWithMemberResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/RentPropertyWithMemberResponseDTO.java
@@ -1,0 +1,71 @@
+package org.hanihome.hanihomebe.property.web.dto.response;
+
+import org.hanihome.hanihomebe.interest.region.Region;
+import org.hanihome.hanihomebe.item.web.dto.OptionItemResponseDTO;
+import org.hanihome.hanihomebe.member.web.dto.MemberSummaryDTO;
+import org.hanihome.hanihomebe.property.domain.enums.*;
+import org.hanihome.hanihomebe.property.domain.vo.CostDetails;
+import org.hanihome.hanihomebe.property.domain.vo.LivingConditions;
+import org.hanihome.hanihomebe.property.domain.vo.MoveInInfo;
+import org.hanihome.hanihomebe.property.domain.vo.RentInternalDetails;
+import org.hanihome.hanihomebe.property.web.dto.response.basic.RentPropertyResponseDTO;
+import org.hanihome.hanihomebe.property.web.dto.response.summary.MetaInfo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RentPropertyWithMemberResponseDTO(
+        Long id,
+        PropertySuperType kind,
+        RentPropertySubType rentPropertySubType,    // (RentProperty 고유) 매물 유형
+        DisplayStatus displayStatus,
+        TradeStatus tradeStatus,
+        int wishCount,
+        LocalDateTime createdAt,
+        LocalDateTime lastModifiedAt,
+        Long memberId,
+        List<OptionItemResponseDTO> optionItems,
+        GenderPreference genderPreference,
+        boolean lgbtAvailable,
+        Region region,
+        List<String> photoUrls,
+        String thumbnailUrl,
+        CostDetails costDetails,
+        LivingConditions livingConditions,
+        MoveInInfo moveInInfo,
+        String description,
+        RentInternalDetails internalDetails,
+        CapacityRent capacityRent,             // (RentProperty 고유) 수용인원-렌트
+        MemberSummaryDTO hostSummary,
+        MetaInfo metaInfo
+) implements PropertyWithMemberResponseDTO {
+    public static RentPropertyWithMemberResponseDTO from(RentPropertyResponseDTO rentDTO,
+                                                         MemberSummaryDTO hostSummary,
+                                                         MetaInfo metaInfo) {
+        return new RentPropertyWithMemberResponseDTO(
+                rentDTO.id(),
+                rentDTO.kind(),
+                rentDTO.rentPropertySubType(),
+                rentDTO.displayStatus(),
+                rentDTO.tradeStatus(),
+                rentDTO.wishCount(),
+                rentDTO.createdAt(),
+                rentDTO.lastModifiedAt(),
+                rentDTO.memberId(),
+                rentDTO.optionItems(),
+                rentDTO.genderPreference(),
+                rentDTO.lgbtAvailable(),
+                rentDTO.region(),
+                rentDTO.photoUrls(),
+                rentDTO.thumbnailUrl(),
+                rentDTO.costDetails(),
+                rentDTO.livingConditions(),
+                rentDTO.moveInInfo(),
+                rentDTO.description(),
+                rentDTO.internalDetails(),
+                rentDTO.capacityRent(),
+                hostSummary,
+                metaInfo
+        );
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/SharePropertyWithMemberResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/SharePropertyWithMemberResponseDTO.java
@@ -1,0 +1,71 @@
+package org.hanihome.hanihomebe.property.web.dto.response;
+
+import org.hanihome.hanihomebe.interest.region.Region;
+import org.hanihome.hanihomebe.item.web.dto.OptionItemResponseDTO;
+import org.hanihome.hanihomebe.member.web.dto.MemberSummaryDTO;
+import org.hanihome.hanihomebe.property.domain.enums.*;
+import org.hanihome.hanihomebe.property.domain.vo.CostDetails;
+import org.hanihome.hanihomebe.property.domain.vo.LivingConditions;
+import org.hanihome.hanihomebe.property.domain.vo.MoveInInfo;
+import org.hanihome.hanihomebe.property.domain.vo.ShareInternalDetails;
+import org.hanihome.hanihomebe.property.web.dto.response.basic.SharePropertyResponseDTO;
+import org.hanihome.hanihomebe.property.web.dto.response.summary.MetaInfo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record SharePropertyWithMemberResponseDTO(
+        Long id,
+        PropertySuperType kind,
+        SharePropertySubType sharePropertySubType,                // 1. 매물 유형 (세컨드룸/마스터룸/거실쉐어)
+        DisplayStatus displayStatus,
+        TradeStatus tradeStatus,
+        int wishCount,
+        LocalDateTime createdAt,
+        LocalDateTime lastModifiedAt,
+        Long memberId,
+        List<OptionItemResponseDTO> optionItems,
+        GenderPreference genderPreference,
+        boolean lgbtAvailable,
+        Region region,
+        List<String> photoUrls,
+        String thumbnailUrl,
+        CostDetails costDetails,
+        LivingConditions livingConditions,
+        MoveInInfo moveInInfo,
+        String description,
+        ShareInternalDetails internalDetails,                       // 2-6. 해당 매물의 층수
+        CapacityShare capacityShare,                             // 3. 수용 인원
+        MemberSummaryDTO hostSummary,
+        MetaInfo metaInfo
+) implements PropertyWithMemberResponseDTO {
+    public static SharePropertyWithMemberResponseDTO from(SharePropertyResponseDTO shareDTO,
+                                                          MemberSummaryDTO hostSummary,
+                                                          MetaInfo metaInfo) {
+        return new SharePropertyWithMemberResponseDTO(
+                shareDTO.id(),
+                shareDTO.kind(),
+                shareDTO.sharePropertySubType(),
+                shareDTO.displayStatus(),
+                shareDTO.tradeStatus(),
+                shareDTO.wishCount(),
+                shareDTO.createdAt(),
+                shareDTO.lastModifiedAt(),
+                shareDTO.memberId(),
+                shareDTO.optionItems(),
+                shareDTO.genderPreference(),
+                shareDTO.lgbtAvailable(),
+                shareDTO.region(),
+                shareDTO.photoUrls(),
+                shareDTO.thumbnailUrl(),
+                shareDTO.costDetails(),
+                shareDTO.livingConditions(),
+                shareDTO.moveInInfo(),
+                shareDTO.description(),
+                shareDTO.internalDetails(),
+                shareDTO.capacityShare(),
+                hostSummary,
+                metaInfo
+        );
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/RentPropertyResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/RentPropertyResponseDTO.java
@@ -33,10 +33,6 @@ public record RentPropertyResponseDTO(
         String description,
         RentInternalDetails internalDetails,
         CapacityRent capacityRent                  // (RentProperty 고유) 수용인원-렌트
-        //        LocalDate meetingDateFrom,
-//        LocalDate meetingDateTo,
-//        List<TimeSlot> timeSlots,
-        // viewingAvailableDateTime는 응답에서 제외
 )implements PropertyResponseDTO {
     public static RentPropertyResponseDTO from(RentProperty rentProperty, List<OptionItemResponseDTO> optionItems) {
 

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/SharePropertyResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/SharePropertyResponseDTO.java
@@ -34,10 +34,6 @@ public record SharePropertyResponseDTO(
         String description,
         ShareInternalDetails internalDetails,                       // 2-6. 해당 매물의 층수
         CapacityShare capacityShare                             // 3. 수용 인원
-//        LocalDate meetingDateFrom,
-//        LocalDate meetingDateTo,
-//        List<TimeSlot> timeSlots,
-        // viewingAvailableDateTime는 응답에서 제외
 ) implements PropertyResponseDTO {
     public static SharePropertyResponseDTO from(ShareProperty shareProperty, List<OptionItemResponseDTO> optionItems) {
         if (shareProperty == null) {

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/MetaInfo.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/MetaInfo.java
@@ -1,0 +1,10 @@
+package org.hanihome.hanihomebe.property.web.dto.response.summary;
+
+public record MetaInfo(
+        boolean owner,
+        boolean wished
+) {
+    public static MetaInfo create(boolean owner, boolean wished) {
+        return new MetaInfo(owner, wished);
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/PropertySummaryDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/PropertySummaryDTO.java
@@ -43,4 +43,6 @@ public sealed interface PropertySummaryDTO
     int wishCount();
 
     TradeStatus tradeStatus();
+
+    MetaInfo metaInfo();
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/RentPropertySummaryDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/RentPropertySummaryDTO.java
@@ -23,9 +23,12 @@ public record RentPropertySummaryDTO(
         String thumbnailUrl,
         LocalDateTime createdAt,
         int wishCount,
-        TradeStatus tradeStatus
+        TradeStatus tradeStatus,
+        MetaInfo metaInfo
 ) implements PropertySummaryDTO {
-    public static RentPropertySummaryDTO from(RentProperty entity, NearestMetroStopResponseDTO nearestMetroStopResponseDTO) {
+    public static RentPropertySummaryDTO from(RentProperty entity,
+                                              NearestMetroStopResponseDTO nearestMetroStopResponseDTO,
+                                              MetaInfo metaInfo) {
         return new RentPropertySummaryDTO(
                 entity.getId(),
                 entity.getKind(),
@@ -39,7 +42,8 @@ public record RentPropertySummaryDTO(
                 entity.getThumbnailUrl(),
                 entity.getCreatedAt(),
                 entity.getWishCount(),
-                entity.getTradeStatus()
+                entity.getTradeStatus(),
+                metaInfo
         );
     }
 

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/SharePropertySummaryDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/SharePropertySummaryDTO.java
@@ -23,9 +23,13 @@ public record SharePropertySummaryDTO(
         String thumbnailUrl,
         LocalDateTime createdAt,
         int wishCount,
-        TradeStatus tradeStatus
+        TradeStatus tradeStatus,
+        MetaInfo metaInfo
 ) implements PropertySummaryDTO {
-    public static SharePropertySummaryDTO from(ShareProperty entity, NearestMetroStopResponseDTO nearestMetroStopResponseDTO) {
+    public static SharePropertySummaryDTO from(ShareProperty entity,
+                                               NearestMetroStopResponseDTO nearestMetroStopResponseDTO,
+                                               MetaInfo metaInfo
+                                               ) {
         return new SharePropertySummaryDTO(
                 entity.getId(),
                 entity.getKind(),
@@ -39,7 +43,8 @@ public record SharePropertySummaryDTO(
                 entity.getThumbnailUrl(),
                 entity.getCreatedAt(),
                 entity.getWishCount(),
-                entity.getTradeStatus()
+                entity.getTradeStatus(),
+                metaInfo
         );
     }
 

--- a/src/main/java/org/hanihome/hanihomebe/viewing/application/service/ViewingConversionService.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/application/service/ViewingConversionService.java
@@ -1,17 +1,15 @@
 package org.hanihome.hanihomebe.viewing.application.service;
 
-import org.hanihome.hanihomebe.HaniHomeBeApplication;
+import org.hanihome.hanihomebe.global.exception.CustomException;
+import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
+import org.hanihome.hanihomebe.global.utility.SecurityContextUtils;
 import org.hanihome.hanihomebe.item.application.converter.OptionItemConverterForViewing;
 import org.hanihome.hanihomebe.item.web.dto.OptionItemResponseDTO;
-import org.hanihome.hanihomebe.security.auth.user.detail.CustomUserDetails;
 import org.hanihome.hanihomebe.viewing.domain.Viewing;
 import org.hanihome.hanihomebe.viewing.web.converter.ViewingConverter;
 import org.hanihome.hanihomebe.viewing.web.converter.context.ViewingConvertContext;
 import org.hanihome.hanihomebe.viewing.web.enums.ViewingViewType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +28,8 @@ public class ViewingConversionService {
     }
 
     public <T> T convert(Viewing viewing, ViewingViewType view) {
-        Long requesterId = getHttpRequesterId();
+        Long requesterId = SecurityContextUtils.getHttpRequesterId()
+                .orElseThrow(()->new CustomException(ServiceCode.NEED_TO_AUTHENTICATED));
         List<OptionItemResponseDTO> optionItemResponseDTOs = optionItemConverter.toOptionItemResponseDTO(List.copyOf(viewing.getViewingOptionItems()));
 
         ViewingConverter<T> converter = getConverter(view);
@@ -43,7 +42,8 @@ public class ViewingConversionService {
     }
 
     private <T> List<T> convertViewingListToDTO(List<Viewing> viewings, ViewingViewType view) {
-        Long requesterId = getHttpRequesterId();
+        Long requesterId = SecurityContextUtils.getHttpRequesterId()
+                .orElseThrow(()->new CustomException(ServiceCode.NEED_TO_AUTHENTICATED));
         ViewingConverter<T> converter = getConverter(view);
 
         return viewings.stream()
@@ -52,18 +52,6 @@ public class ViewingConversionService {
                     return converter.convert(ViewingConvertContext.create(viewing, requesterId, optionItemResponseDTOs));
                 })
                 .toList();
-    }
-
-    private static Long getHttpRequesterId() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = getCustomUserDetails(auth);
-        Long requesterId = userDetails.getUserId();
-        return requesterId;
-    }
-
-    private static CustomUserDetails getCustomUserDetails(Authentication auth) {
-        CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
-        return userDetails;
     }
 
     private <T> ViewingConverter<T> getConverter(ViewingViewType type) {

--- a/src/main/java/org/hanihome/hanihomebe/viewing/web/converter/ViewingDateWithPropertyConverter.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/web/converter/ViewingDateWithPropertyConverter.java
@@ -31,7 +31,13 @@ public class ViewingDateWithPropertyConverter implements ViewingConverter<Viewin
 
         PropertySummaryDTO propertySummaryDTO = getPropertySummaryDTO(viewing);
 
-        return ViewingDateWithPropertyDTO.from(viewing.getMeetingDay(), propertySummaryDTO);
+        String counterPartNickname = getCounterPartNickname(viewingConvertContext.getRequesterId(), viewing);
+
+        return ViewingDateWithPropertyDTO.from(
+                viewing.getMeetingDay(),
+                propertySummaryDTO,
+                counterPartNickname
+        );
     }
 
     private PropertySummaryDTO getPropertySummaryDTO(Viewing viewing) {
@@ -42,5 +48,23 @@ public class ViewingDateWithPropertyConverter implements ViewingConverter<Viewin
                 .orElseThrow(() -> new CustomException(ServiceCode.PROPERTY_IN_VIEWING_CONVERT_EXCEPTION));
         return propertySummaryDTO;
     }
+    private String getCounterPartNickname(Long requesterId, Viewing viewing) {
+        if (requesterIsGuest(requesterId, viewing)) {
+            return getHostNickname(viewing);
+        } else {
+            return getGuestNickname(viewing);
+        }
+    }
 
+    private static String getGuestNickname(Viewing viewing) {
+        return viewing.getMember().getNickname();
+    }
+
+    private static String getHostNickname(Viewing viewing) {
+        return viewing.getProperty().getMember().getNickname();
+    }
+
+    private static boolean requesterIsGuest(Long requesterId, Viewing viewing) {
+        return requesterId.equals(viewing.getMember().getId());
+    }
 }

--- a/src/main/java/org/hanihome/hanihomebe/viewing/web/dto/ViewingBelongsToPropertyDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/web/dto/ViewingBelongsToPropertyDTO.java
@@ -11,7 +11,7 @@ public record ViewingBelongsToPropertyDTO(
         String propertyThumbnailUrl,
         LocalDate meetingDate,
         LocalTime meetingTime
-) {
+) implements ViewingDTOByView{
     public static ViewingBelongsToPropertyDTO create(Long viewingId, Long guestId, String guestNickName, String guestThumbnailUrl, String propertyThumbnailUrl, LocalDate meetingDate, LocalTime meetingTime) {
         return new ViewingBelongsToPropertyDTO(
                 viewingId,

--- a/src/main/java/org/hanihome/hanihomebe/viewing/web/dto/ViewingDateWithPropertyDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/web/dto/ViewingDateWithPropertyDTO.java
@@ -6,9 +6,12 @@ import java.time.LocalDateTime;
 
 public record ViewingDateWithPropertyDTO(
         LocalDateTime meetingDay,
-        PropertySummaryDTO property
+        PropertySummaryDTO property,
+        String counterpartNickname
 ) implements ViewingDTOByView {
-    public static ViewingDateWithPropertyDTO from(LocalDateTime meetingDay, PropertySummaryDTO property) {
-        return new ViewingDateWithPropertyDTO(meetingDay, property);
+    public static ViewingDateWithPropertyDTO from(LocalDateTime meetingDay,
+                                                  PropertySummaryDTO property,
+                                                  String counterpartNickname) {
+        return new ViewingDateWithPropertyDTO(meetingDay, property, counterpartNickname);
     }
 }

--- a/src/test/java/org/hanihome/hanihomebe/property/application/service/PropertyServiceTest.java
+++ b/src/test/java/org/hanihome/hanihomebe/property/application/service/PropertyServiceTest.java
@@ -19,6 +19,7 @@ import org.hanihome.hanihomebe.property.domain.vo.*;
 import org.hanihome.hanihomebe.property.web.dto.request.PropertyCompleteTradeDTO;
 import org.hanihome.hanihomebe.property.web.dto.request.create.RentPropertyCreateRequestDTO;
 import org.hanihome.hanihomebe.property.web.dto.request.create.SharePropertyCreateRequestDTO;
+import org.hanihome.hanihomebe.property.web.dto.response.PropertyWithMemberResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.basic.PropertyResponseDTO;
 import org.hanihome.hanihomebe.security.auth.user.detail.CustomUserDetails;
 import org.hanihome.hanihomebe.viewing.application.service.ViewingService;
@@ -128,7 +129,7 @@ class PropertyServiceTest {
     void bookingAndDealFlow() {
         // Given: 호스트가 매물 등록
         SharePropertyCreateRequestDTO dto = buildSharePropertyDTO(memberId);
-        PropertyResponseDTO created = propertyService.createProperty(dto);
+        PropertyWithMemberResponseDTO created = propertyService.createProperty(dto);
         Long propertyId = created.id();
 
         // Given: Member2, Member3 생성
@@ -191,7 +192,7 @@ class PropertyServiceTest {
     void bookingAndDealFlow_RentProperty() {
         // Given: 호스트가 매물 등록
         RentPropertyCreateRequestDTO dto = buildRentPropertyDTO(memberId);
-        PropertyResponseDTO created = propertyService.createProperty(dto);
+        PropertyWithMemberResponseDTO created = propertyService.createProperty(dto);
         Long propertyId = created.id();
 
         // Given: Member2, Member3 생성


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #181 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->

1. 매물 응답 DTO에 소유자 정보 추가 
문제상황: 매물 조회에 대한 응답으로 회원 도메인의 정보를 같이 내려줘야한다. 
해결: 매물 컨버터에서 회원 도메인의 정보까지 DTO로 같이 제공해야하는지 고민을 많이 하였다. PropertyResponseDTO리스트를 받고 반복을 돌면서 MemberSummaryDTO를 조합하여 PropertyWithMemberResponseDTO를 `Assembler` 클래스에서 만드는게 더 좋았을지 의견을 주십쇼..
> 그런데 Assembler의 문제점은 viewType=SUMMARY 일 때는 MemberSummaryDTO를 조합하지 않아도 된다는거다. > viewType별로 Assembler도 추상화를 해도 좋지만 너무 많은 추상화 계층이 발생..

-> 일단 컨버터의 책임 범위를 `PropertyViewType` 과 엮었으므로 회원 도메인 처리에도 문제가 없겠다고 판단.

2. 소유자 여부, 즐겨찾기(찜) 여부
PropertyConversionService에서 PropertyConvertContext 생성 시에 메타데이터로서 저장하도록 추가하였다.

3. 뷰잉 DATE_WITH_PROPERTY 조회 시 상대방 닉네임 조회가능

## 📚 Reference
적용되는 화면은 이슈를 참고.


### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
