### PR TITLE
[FIX] 게스트 모드(token이 없을 시)일 때 필터 오류 해결

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/global/utility/SecurityContextUtils.java
+++ b/src/main/java/org/hanihome/hanihomebe/global/utility/SecurityContextUtils.java
@@ -7,7 +7,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import java.util.Optional;
 
 public class SecurityContextUtils {
-
+    /*
     public static Optional<Long> getHttpRequesterId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null) {
@@ -15,5 +15,24 @@ public class SecurityContextUtils {
         }
         CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
         return Optional.of(userDetails.getUserId());
+    }
+     */
+
+    public static Optional<Long> getHttpRequesterId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+
+        //인증안된 친구
+        if (auth == null || !auth.isAuthenticated()) {
+            return Optional.empty();
+        }
+
+        //인증된 친구
+        Object principal = auth.getPrincipal();
+        if (principal instanceof CustomUserDetails customUserDetails) {
+            return Optional.of(customUserDetails.getUserId());
+        }
+
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/security/auth/application/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/hanihome/hanihomebe/security/auth/application/filter/JwtAuthenticationFilter.java
@@ -103,6 +103,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         } catch (Exception e) {
             log.error("Unexpected error in JwtAuthenticationFilter", e);
             setErrorResponse(response, NOT_DEFINED_ERROR_FROM_FILTER);
+            //여기서도 일단 다음 필터로 넘ㅇ겨야할까? SecurityConfig에서 확인하면 되려나
         }
     }
 

--- a/src/main/java/org/hanihome/hanihomebe/security/config/SecurityConfig.java
+++ b/src/main/java/org/hanihome/hanihomebe/security/config/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET,
                                 "/api/v1/properties/categories/**",
                                 "/api/v1/viewings/categories/**",
-                                "/api/v1/properties"
+                                "/api/v1/properties",
+                                "api/v1/properties/search"
                         ).permitAll()
                         .requestMatchers(
                                 "/api/v1/auth/social/login",

--- a/src/main/java/org/hanihome/hanihomebe/security/config/SecurityConfig.java
+++ b/src/main/java/org/hanihome/hanihomebe/security/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET,
-                                "api/v1/properties/categories/**",
+                                "/api/v1/properties/categories/**",
                                 "/api/v1/viewings/categories/**",
                                 "/api/v1/properties"
                         ).permitAll()


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #185 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
[src/main/java/org/hanihome/hanihomebe/global/utility/SecurityContextUtils.java](https://github.com/Hani-home/HaniHome_BE/pull/186/files/c5ff1c06890eb2272a930830055036a12825f7b2#diff-076f6e2525417631e987ed9d92017b0857a1a77749f3fa49e1cc9cd956ca3361)

요거만 확인해주시면 됩니다.

문제상황: 비로그인 사용자가 /api/v1/properties 에 GET 요청을 보내면 다음과 같은 오류가 뜸

<img width="652" height="820" alt="image" src="https://github.com/user-attachments/assets/1cf701e1-16b1-4f98-bb57-fa0c79491b1b" />

원인
<img width="1091" height="302" alt="image" src="https://github.com/user-attachments/assets/f1f63aa0-b034-4068-b9c1-314fe000ca0c" />
기존 코드인데

로그인을 안하면
CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();

여기서 null 확인해서 분기처리는 했지만 비로그인 사용자여도 Authentication 객체가 null이 아닌 상태로 존재한다고 하더라고요.

그래서 userDetails가 "anonymousUser" 로 String으로 나와서 타입 문제가 생김.

그래서 분기처리 조건 더 빡세게 해두었습니다.

그리고 프론트에서 properties/search도 게스트가 사용할 수 있게 해달라해서 열어두겠습니다



## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
