### PR TITLE
[FIX] #189 알림 목록 조회 오류 해결 - 미전송 알림은 조회 안함

### DIFF
--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -1,0 +1,43 @@
+name: Check Style and Test to Develop
+
+on:
+  pull_request:
+    branches: ["develop"]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: JDK 설치
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: gradlew 권한 부여
+        run: chmod +x ./gradlew
+
+#      # Redis 컨테이너 실행
+#      - name: Start containers
+#        run: docker compose -f docker-compose-test.yaml up -d
+
+      - name: Setup Gradle
+        id: gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }} # feature 브랜치는 캐시를 읽기 전용으로 설정
+#          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+          add-job-summary-as-pr-comment: always
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
+          build-scan-terms-of-use-agree: "yes"
+
+      - name: Check with Gradle
+        run: ./gradlew check --configuration-cache -x test --configuration-cache

--- a/src/main/java/org/hanihome/hanihomebe/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/hanihome/hanihomebe/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.global.response.dto.CommonResponse;
 import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -33,4 +34,24 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(serviceCode.getHttpStatus().value())
                 .body(commonResponse);
     }
+
+    // FK 제약 위반 시 처리
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<CommonResponse> handleDataIntegrityViolation(
+            DataIntegrityViolationException e, HttpServletRequest request) {
+        // API-docs 예외 처리 제외
+        if (request.getRequestURI().startsWith("/v3/api-docs")) {
+            return ResponseEntity.ok().build();
+        }
+
+        log.error("DataIntegrityViolationException 발생: {}", e.getMessage(), e);
+        ServiceCode serviceCode = ServiceCode.DELETE_FAILED_HAS_RELATION;
+
+        CommonResponse<ErrorResponseDTO> commonResponse =
+                CommonResponse.failure(ErrorResponseDTO.of(serviceCode), serviceCode);
+        return ResponseEntity
+                .status(serviceCode.getHttpStatus().value())
+                .body(commonResponse);
+    }
+
 }

--- a/src/main/java/org/hanihome/hanihomebe/global/response/domain/ServiceCode.java
+++ b/src/main/java/org/hanihome/hanihomebe/global/response/domain/ServiceCode.java
@@ -44,6 +44,7 @@ public enum ServiceCode {
     PROPERTY_CONVERTER_MISMATCH(HttpStatus.BAD_REQUEST, "잘못된 PropertyConverter가 사용되었습니다"),
     PROPERTY_IS_HIDDEN(HttpStatus.NOT_FOUND, "요청한 매물은 숨김처리되었습니다."),
     PROPERTY_HAS_REQUESTED_VIEWINGS(HttpStatus.BAD_REQUEST, "요청한 매물은 예약확정 상태의 뷰잉이 존재합니다"),
+    PROPERTY_DELETE_FAILED_HAS_RELATIONS(HttpStatus.INTERNAL_SERVER_ERROR, "매물과 연관된 엔티티가 남아있으므로 삭제에 실패했습니다."),
 
     // Viewing
     VIEWING_NUMBER_NOT_SATISFIED(HttpStatus.BAD_REQUEST, "요청 가능한 뷰잉 시간대는 최소 1개 최대 3개입니다"),
@@ -113,6 +114,7 @@ public enum ServiceCode {
 
     // security 인증/인가
     NEED_TO_AUTHENTICATED(HttpStatus.INTERNAL_SERVER_ERROR, "해당 요청은 인증이 필요합니다. 하지만 로그인되지 않은 사용자가 필터를 통과했습니다."),
+    DELETE_FAILED_HAS_RELATION(HttpStatus.INTERNAL_SERVER_ERROR, "연관된 엔티티가 있어 삭제에 실패했습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/hanihome/hanihomebe/metro/application/service/NearestMetroStopService.java
+++ b/src/main/java/org/hanihome/hanihomebe/metro/application/service/NearestMetroStopService.java
@@ -28,4 +28,9 @@ public class NearestMetroStopService {
 
         return nearestMetroStopRepository.save(NearestMetroStop.create(findMetroStop, property, distance));
     }
+
+    @Transactional
+    public void deleteByPropertyId(Long propertyId) {
+        nearestMetroStopRepository.deleteByProperty_Id(propertyId);
+    }
 }

--- a/src/main/java/org/hanihome/hanihomebe/metro/repository/NearestMetroStopRepository.java
+++ b/src/main/java/org/hanihome/hanihomebe/metro/repository/NearestMetroStopRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 @Repository
 public interface NearestMetroStopRepository extends JpaRepository<NearestMetroStop, Long> {
     Optional<NearestMetroStop> findByProperty(Property property);
+
+    void deleteByProperty_Id(Long propertyId);
 }

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationMessageFactory.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationMessageFactory.java
@@ -65,7 +65,8 @@ public class NotificationMessageFactory {
 
 
         NotificationCreateDTO hostDTO = NotificationCreateDTO.create(hostId, title, content, NotificationType.VIEWING_REMINDER);
-        return List.of(NotificationCreateDTO.create(guestId, title, content, NotificationType.VIEWING_REMINDER), hostDTO);
+        NotificationCreateDTO guestDTO = NotificationCreateDTO.create(guestId, title, content, NotificationType.VIEWING_REMINDER);
+        return List.of(guestDTO, hostDTO);
     }
 
     public NotificationCreateDTO createOneOnOneConsultRepliedMessage(Long receiverId) {

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationPushService.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationPushService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hanihome.hanihomebe.global.exception.CustomException;
 import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.notification.domain.Notification;
+import org.hanihome.hanihomebe.notification.domain.NotificationSendStatus;
 import org.hanihome.hanihomebe.notification.repository.NotificationRepository;
 import org.hanihome.hanihomebe.notification.web.dto.NotificationResponseDTO;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ public class NotificationPushService {
   * @param notificationId 전송할 알림 엔티티
   */
  // TODO: 성능개선: 비동기 알림 발송
+ @Transactional
  public void pushNotification(Long notificationId) {
      Notification findNotification = notificationRepository.findById(notificationId)
              .orElseThrow(() -> new CustomException(ServiceCode.NOTIFICATION_NOT_EXISTS));
@@ -37,6 +39,8 @@ public class NotificationPushService {
              "}, notificationId: {}", receiverId, notificationId);
      if (userEmitters == null || userEmitters.isEmpty()) {
          log.info("SSE emitter 없음: receiverId={}", receiverId);
+
+         updateNotificationAsSuccess(findNotification);
          return;
      }
 
@@ -46,18 +50,32 @@ public class NotificationPushService {
          try {
              emitter.send(SseEmitter.event()
                      .id(findNotification.getId().toString())
-                     .name(findNotification.getType().name())
+                     .name(findNotification.getType().name()) // 클라이언트의 이벤트 리스너는 해당 이름으로 수신해야함
                      .data(NotificationResponseDTO.from(findNotification)));
              log.info("SSE 전송 성공: receiverId={}, emitterId={}", receiverId, id);
+
+             updateNotificationAsSuccess(findNotification);
          } catch (IOException e) {
              log.warn("SSE 전송 실패: receiverId={}, notificationId={}, emitterId={}, error={}",
                      receiverId, notificationId, id, e.toString());
+
+             updateNotificationAsFailed(findNotification);
              emitterService.removeEmitter(receiverId, id);
          } catch (Exception e) {
              log.info("message:{}", e.toString());
+
+             updateNotificationAsFailed(findNotification);
              throw new CustomException(ServiceCode.NOTIFICATION_SEND_FAILED, e);
          }
      });
 
  }
+
+    private static void updateNotificationAsFailed(Notification findNotification) {
+        findNotification.updateSendStatus(NotificationSendStatus.FAILED);
+    }
+
+    private static void updateNotificationAsSuccess(Notification findNotification) {
+        findNotification.updateSendStatus(NotificationSendStatus.SUCCESS);
+    }
 }

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationService.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationService.java
@@ -7,6 +7,7 @@ import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.member.domain.Member;
 import org.hanihome.hanihomebe.member.repository.MemberRepository;
 import org.hanihome.hanihomebe.notification.domain.Notification;
+import org.hanihome.hanihomebe.notification.domain.NotificationSendStatus;
 import org.hanihome.hanihomebe.notification.repository.NotificationRepository;
 import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
 import org.hanihome.hanihomebe.notification.web.dto.NotificationResponseDTO;
@@ -36,7 +37,7 @@ public class NotificationService {
      * @return 알림 리스트
      */
     public List<Notification> getMyNotifications(Long userId, Boolean isRead) {
-        return notificationRepository.findMyNotificationAndIsReadOptional(userId, isRead);
+        return notificationRepository.findMyNotificationByIsReadOptionalAndSendStatus(userId, isRead, NotificationSendStatus.SUCCESS);
     }
 
     /**

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationService.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationService.java
@@ -37,7 +37,7 @@ public class NotificationService {
      * @return 알림 리스트
      */
     public List<Notification> getMyNotifications(Long userId, Boolean isRead) {
-        return notificationRepository.findMyNotificationByIsReadOptionalAndSendStatus(userId, isRead, NotificationSendStatus.SUCCESS);
+        return notificationRepository.findMyNotificationByIsReadOptionalAndSendStatus(userId, isRead, List.of(NotificationSendStatus.SUCCESS, NotificationSendStatus.FAILED));
     }
 
     /**

--- a/src/main/java/org/hanihome/hanihomebe/notification/domain/Notification.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/domain/Notification.java
@@ -29,6 +29,9 @@ public class Notification extends BaseEntity {
     private boolean isRead;
 
     @Enumerated(EnumType.STRING)
+    private NotificationSendStatus notificationSendStatus; // 조회 시 sendStatus가 SUCCESS인 것만 조회되어야한다.
+
+    @Enumerated(EnumType.STRING)
     private NotificationType type; // VIEWING_REMINDER, VIEWING_CREATED, VIEWING_CANCELED
 
     public static Notification create(Member receiver, String title, String content, NotificationType type) {
@@ -38,11 +41,16 @@ public class Notification extends BaseEntity {
                 .content(content)
                 .type(type)
                 .isRead(false)
+                .notificationSendStatus(NotificationSendStatus.PENDING)
                 .build();
     }
 
     public void updateAsRead() {
         this.isRead = true;
+    }
+
+    public void updateSendStatus(NotificationSendStatus notificationSendStatus) {
+        this.notificationSendStatus = notificationSendStatus;
     }
 }
 

--- a/src/main/java/org/hanihome/hanihomebe/notification/domain/NotificationSendStatus.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/domain/NotificationSendStatus.java
@@ -1,0 +1,13 @@
+package org.hanihome.hanihomebe.notification.domain;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum NotificationSendStatus {
+    PENDING("전송 대기 중, 조회 불가능"),
+    SUCCESS("sse 전송에 서버측 문제는 없음, 조회 가능"), // sse 전송 후 실제 수신까지 성공 or sse 전송 시도에는 오류가 없으나 클라이언트가 sse 미연결이라 전송은 안됐음 but 문제 없음
+    FAILED("sse 전송 실패, 조회 가능"),
+    CANCELLED("전송 취소, 조회 불가능"),
+    ;
+    private final String description;
+}

--- a/src/main/java/org/hanihome/hanihomebe/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package org.hanihome.hanihomebe.notification.repository;
 
 import org.hanihome.hanihomebe.notification.domain.Notification;
+import org.hanihome.hanihomebe.notification.domain.NotificationSendStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -21,7 +22,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
      */
     @Query("select n from Notification n " +
             "where n.receiver.id = :receiverId " +
-            "and (:isRead is null or n.isRead = :isRead)")
-    List<Notification> findMyNotificationAndIsReadOptional(Long receiverId, Boolean isRead);
+            "and (:isRead is null or n.isRead = :isRead) and n.notificationSendStatus = :notificationSendStatus")
+    List<Notification> findMyNotificationByIsReadOptionalAndSendStatus(Long receiverId,
+                                                                       Boolean isRead,
+                                                                       NotificationSendStatus notificationSendStatus);
 
 }

--- a/src/main/java/org/hanihome/hanihomebe/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/repository/NotificationRepository.java
@@ -22,9 +22,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
      */
     @Query("select n from Notification n " +
             "where n.receiver.id = :receiverId " +
-            "and (:isRead is null or n.isRead = :isRead) and n.notificationSendStatus = :notificationSendStatus")
+            "and (:isRead is null or n.isRead = :isRead) and n.notificationSendStatus in :sendStatusList")
     List<Notification> findMyNotificationByIsReadOptionalAndSendStatus(Long receiverId,
                                                                        Boolean isRead,
-                                                                       NotificationSendStatus notificationSendStatus);
+                                                                       List<NotificationSendStatus> sendStatusList);
 
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyService.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyService.java
@@ -9,6 +9,7 @@ import org.hanihome.hanihomebe.global.utility.SecurityContextUtils;
 import org.hanihome.hanihomebe.member.domain.Member;
 import org.hanihome.hanihomebe.member.repository.MemberRepository;
 import org.hanihome.hanihomebe.metro.application.service.NearestMetroStopService;
+import org.hanihome.hanihomebe.metro.repository.NearestMetroStopRepository;
 import org.hanihome.hanihomebe.property.application.factory.PropertyFactory;
 import org.hanihome.hanihomebe.property.domain.Property;
 import org.hanihome.hanihomebe.item.domain.OptionItem;
@@ -30,6 +31,7 @@ import org.hanihome.hanihomebe.viewing.repository.ViewingRepository;
 import org.hanihome.hanihomebe.wishlist.domain.enums.WishTargetType;
 import org.hanihome.hanihomebe.wishlist.repository.WishItemRepository;
 import org.springdoc.webmvc.core.service.RequestService;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,7 +54,6 @@ public class PropertyService {
     private final List<PropertyFactory> propertyFactories;
     private final DealService dealService;
     private final ViewingService viewingService;
-    private final RequestService requestService;
     private final ViewingRepository viewingRepository;
 
 
@@ -218,15 +219,20 @@ public class PropertyService {
     /// delete
     @Transactional
     public void deletePropertyById(Long id) {
-        if (!propertyRepository.existsById(id)) {
-            throw new CustomException(ServiceCode.PROPERTY_NOT_EXISTS);
+            if (!propertyRepository.existsById(id)) {
+                throw new CustomException(ServiceCode.PROPERTY_NOT_EXISTS);
+            }
+            if (propertyHasViewingsInREQUESTED(id)) {
+                throw new CustomException(ServiceCode.PROPERTY_HAS_REQUESTED_VIEWINGS);
+            }
+            wishItemRepository.deleteAllByTargetTypeAndTargetId(WishTargetType.PROPERTY, id); //해당 찜하기 삭제
+            viewingRepository.deleteByProperty_Id(id);
+            nearestMetroStopService.deleteByPropertyId(id);
+        try {
+            propertyRepository.deleteById(id);
+        }catch (DataIntegrityViolationException e){
+            throw new CustomException(ServiceCode.PROPERTY_DELETE_FAILED_HAS_RELATIONS, e);
         }
-        if (propertyHasViewingsInREQUESTED(id)) {
-            throw new CustomException(ServiceCode.PROPERTY_HAS_REQUESTED_VIEWINGS);
-        }
-        wishItemRepository.deleteAllByTargetTypeAndTargetId(WishTargetType.PROPERTY, id); //해당 찜하기 삭제
-
-        propertyRepository.deleteById(id);
     }
 
     private boolean propertyHasViewingsInREQUESTED(Long id) {

--- a/src/main/java/org/hanihome/hanihomebe/viewing/repository/ViewingRepository.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/repository/ViewingRepository.java
@@ -1,6 +1,7 @@
 package org.hanihome.hanihomebe.viewing.repository;
 
 import org.hanihome.hanihomebe.member.domain.Member;
+import org.hanihome.hanihomebe.property.domain.Property;
 import org.hanihome.hanihomebe.viewing.domain.Viewing;
 import org.hanihome.hanihomebe.viewing.domain.ViewingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -37,4 +38,5 @@ public interface ViewingRepository extends JpaRepository<Viewing, Long>, CustomV
             "and (:status is null or :status = v.status)")
     List<Viewing> findViewingsAsHostAndStatus(Long memberId, ViewingStatus status);
 
+    void deleteByProperty_Id(Long propertyId);
 }


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #189 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
1. 알림 전송 상태필드 추가 
기존에는 전송된 알림이 아님에도 불구하고 작업 스케줄러에 등록만 해놓은 Notification도 /nofications/my-notifications 조회 시에 노출되었음. 
-> 실제 알림이 전송될 때 `NotificationSendStatus`를 변경하도록하여 실제 전송처리된 알림만 조회되도록 변경

2. 매물 삭제
매물 삭제 시에 연관된 엔티티가 db에 있으면 FK 제약조건 위반으로 매물 삭제가 안되었음. 연관 엔티티 모두 정리하도록 하여 매물 삭제가 가능하도록 수정하였음. (필요 시 soft delete 추후 적용)

3. PR 업로드 시 gradlew check 자동화 도입
## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
