### PR TITLE
[REFACTOR]#115 DDL 변경

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/admin/customerservice/domain/OneOnOneConsult.java
+++ b/src/main/java/org/hanihome/hanihomebe/admin/customerservice/domain/OneOnOneConsult.java
@@ -10,7 +10,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder(access = AccessLevel.PROTECTED)
-@Table(name = "one_on_one_consults")
+@Table(name = "one_on_one_consult")
 @Entity
 public class OneOnOneConsult {
     @Id @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/org/hanihome/hanihomebe/item/domain/OptionItem.java
+++ b/src/main/java/org/hanihome/hanihomebe/item/domain/OptionItem.java
@@ -13,7 +13,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @AllArgsConstructor
 @Builder
 @Getter
-@Table(name = "option_items",
+@Table(name = "option_item",
         uniqueConstraints = @UniqueConstraint(columnNames = {"option_category_id", "parent_id", "item_name"}) // 유니크 제약조건
 )
 @Entity

--- a/src/main/java/org/hanihome/hanihomebe/notification/domain/Notification.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/domain/Notification.java
@@ -11,7 +11,7 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
 @Builder(access = PROTECTED)
-@Table(name = "notifications")
+@Table(name = "notification")
 @Entity
 public class Notification extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/hanihome/hanihomebe/property/domain/Property.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/domain/Property.java
@@ -29,7 +29,7 @@ import static lombok.AccessLevel.*;
 @SuperBuilder
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.STRING)
-@Table(name = "properties")
+@Table(name = "property")
 @Entity
 public abstract class Property {
 
@@ -135,7 +135,7 @@ public abstract class Property {
      * 최소 1개, 최대 3개(아침, 점심, 저녁)
      */
     @ElementCollection
-    @CollectionTable(name = "property_time_slot",
+    @CollectionTable(name = "property_time_slots",
             joinColumns = @JoinColumn(name = "property_id"))
     @AttributeOverrides({   // 컬렉션 테이블의 칼럼 개수가 2개이므로 값 설정
             @AttributeOverride(
@@ -151,7 +151,7 @@ public abstract class Property {
 
     @Builder.Default
     @ElementCollection
-    @CollectionTable(name = "property_viewing_available_date_time",
+    @CollectionTable(name = "property_viewing_available_date_times",
         joinColumns = @JoinColumn(name = "property_id"))
     @AttributeOverrides({
             @AttributeOverride(

--- a/src/main/java/org/hanihome/hanihomebe/temporaryProperty/domain/TemporaryProperty.java
+++ b/src/main/java/org/hanihome/hanihomebe/temporaryProperty/domain/TemporaryProperty.java
@@ -126,7 +126,7 @@ public abstract class TemporaryProperty {
 
     //4. 계약 사항:  뷰잉 가능 시간대
     @ElementCollection
-    @CollectionTable(name = "temporary_property_time_slot",
+    @CollectionTable(name = "temporary_property_time_slots",
             joinColumns = @JoinColumn(name = "temporary_property_id"))
     @AttributeOverrides({   // 컬렉션 테이블의 칼럼 개수가 2개이므로 값 설정
             @AttributeOverride(
@@ -143,7 +143,7 @@ public abstract class TemporaryProperty {
 
     @Builder.Default
     @ElementCollection
-    @CollectionTable(name = "temporary_property_viewing_available_date_time",
+    @CollectionTable(name = "temporary_property_viewing_available_date_times",
             joinColumns = @JoinColumn(name = "temporary_property_id"))
     @AttributeOverrides({
             @AttributeOverride(

--- a/src/main/java/org/hanihome/hanihomebe/viewing/domain/Viewing.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/domain/Viewing.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Set;
 
 //TODO: guest, host 모두 viewing에서 볼 수 있도록 해야할듯
-@Table(name = "viewings")
+@Table(name = "viewing")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)  // JPA용 기본 생성자
 @AllArgsConstructor


### PR DESCRIPTION
- 기본적으로 엔티티의 테이블 명을 단수로 변경
- 부모 엔티티에 속한 컬렉션 테이블은 복수로 유지

<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #115 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
아래 스크립트를 실행했습니다.
```
show tables;
alter table notifications rename to notification;
alter table one_on_one_consults rename to one_on_one_consult;
alter table properties rename to property;
alter table option_items rename to option_item;
alter table viewings rename to viewing;
alter table property_viewing_available_date_time rename to property_viewing_available_date_times;
alter table property_time_slot rename to property_time_slots;
alter table temporary_property_viewing_available_date_time rename to temporary_property_viewing_available_date_times;
alter table temporary_property_time_slot rename to temporary_property_time_slots;
```

기본적으로 테이블 명은 단수로 변경하되 컬렉션 테이블은 복수로 유지했습니다

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
