### PR TITLE
[REFACTOR]#213 매물 삭제 - 연관엔티티 삭제로직 수정

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyService.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyService.java
@@ -25,6 +25,8 @@ import org.hanihome.hanihomebe.property.web.dto.request.create.PropertyCreateReq
 import org.hanihome.hanihomebe.property.web.dto.request.patch.PropertyPatchRequestDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.PropertyWithMemberResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.TimeWithReserved;
+import org.hanihome.hanihomebe.report.application.domain.ReportTargetType;
+import org.hanihome.hanihomebe.report.service.ReportService;
 import org.hanihome.hanihomebe.viewing.application.service.ViewingService;
 import org.hanihome.hanihomebe.viewing.domain.ViewingStatus;
 import org.hanihome.hanihomebe.viewing.repository.ViewingRepository;
@@ -55,6 +57,7 @@ public class PropertyService {
     private final DealService dealService;
     private final ViewingService viewingService;
     private final ViewingRepository viewingRepository;
+    private final ReportService reportService;
 
 
     /// create
@@ -219,15 +222,17 @@ public class PropertyService {
     /// delete
     @Transactional
     public void deletePropertyById(Long id) {
-            if (!propertyRepository.existsById(id)) {
-                throw new CustomException(ServiceCode.PROPERTY_NOT_EXISTS);
-            }
-            if (propertyHasViewingsInREQUESTED(id)) {
-                throw new CustomException(ServiceCode.PROPERTY_HAS_REQUESTED_VIEWINGS);
-            }
-            wishItemRepository.deleteAllByTargetTypeAndTargetId(WishTargetType.PROPERTY, id); //해당 찜하기 삭제
-            viewingRepository.deleteByProperty_Id(id);
-            nearestMetroStopService.deleteByPropertyId(id);
+        if (!propertyRepository.existsById(id)) {
+            throw new CustomException(ServiceCode.PROPERTY_NOT_EXISTS);
+        }
+        if (propertyHasViewingsInREQUESTED(id)) {
+            throw new CustomException(ServiceCode.PROPERTY_HAS_REQUESTED_VIEWINGS);
+        }
+        wishItemRepository.deleteAllByTargetTypeAndTargetId(WishTargetType.PROPERTY, id); //해당 찜하기 삭제
+        viewingRepository.deleteByProperty_Id(id);
+        nearestMetroStopService.deleteByPropertyId(id);
+        reportService.delete(id, ReportTargetType.PROPERTY);
+
         try {
             propertyRepository.deleteById(id);
         }catch (DataIntegrityViolationException e){

--- a/src/main/java/org/hanihome/hanihomebe/report/application/PropertyReportHandler.java
+++ b/src/main/java/org/hanihome/hanihomebe/report/application/PropertyReportHandler.java
@@ -43,4 +43,9 @@ public class PropertyReportHandler implements ReportHandler {
     public boolean validate(ReportRequestDTO dto) {
         return propertyRepository.existsById(dto.getTargetId());
     }
+
+    @Override
+    public void delete(Long targetId) {
+        propertyReportRepository.deleteById(targetId);
+    }
 }

--- a/src/main/java/org/hanihome/hanihomebe/report/application/ReportHandler.java
+++ b/src/main/java/org/hanihome/hanihomebe/report/application/ReportHandler.java
@@ -9,4 +9,5 @@ public interface ReportHandler {
     ReportTargetType getTargetType();
     Report createAndSave(Member reporter, ReportRequestDTO dto);
     boolean validate(ReportRequestDTO dto);
+    void delete(Long targetId);
 }

--- a/src/main/java/org/hanihome/hanihomebe/report/repository/ReportRepository.java
+++ b/src/main/java/org/hanihome/hanihomebe/report/repository/ReportRepository.java
@@ -4,5 +4,4 @@ import org.hanihome.hanihomebe.report.application.domain.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
-
 }

--- a/src/main/java/org/hanihome/hanihomebe/report/service/ReportService.java
+++ b/src/main/java/org/hanihome/hanihomebe/report/service/ReportService.java
@@ -9,6 +9,7 @@ import org.hanihome.hanihomebe.member.repository.MemberRepository;
 import org.hanihome.hanihomebe.report.application.ReportHandler;
 import org.hanihome.hanihomebe.report.application.domain.Report;
 import org.hanihome.hanihomebe.report.application.domain.ReportTargetType;
+import org.hanihome.hanihomebe.report.repository.ReportRepository;
 import org.hanihome.hanihomebe.report.web.dto.ReportRequestDTO;
 import org.hanihome.hanihomebe.report.web.dto.ReportResponseDTO;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,7 @@ public class ReportService {
     private final Map<ReportTargetType, ReportHandler> reportHandlerMap;
 
     @Autowired
-    public ReportService(List<ReportHandler> handlers, MemberRepository memberRepository) {
+    public ReportService(List<ReportHandler> handlers, MemberRepository memberRepository, ReportRepository reportRepository) {
         this.memberRepository = memberRepository;
         this.reportHandlerMap = handlers.stream()
                 .collect(Collectors.toMap(ReportHandler::getTargetType, h-> h));
@@ -56,5 +57,10 @@ public class ReportService {
 
     //관리자 조회
 
+    @Transactional
+    public void delete(Long targetId, ReportTargetType targetType) {
+        ReportHandler handler = reportHandlerMap.get(targetType);
+        handler.delete(targetId);
+    }
 
 }


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #213 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 매물 삭제시에 연관된 엔티티를 삭제하고 있는데, 이때 PropertyReport도 삭제하는 걸 추가했습니다
- 이를위해 ReportService에서 삭제하는 함수를 구현했습니다.

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
