### PR TITLE
[FIX]/#213 매물 삭제 시 - 연관 엔티티 삭제 로직 수정

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/report/application/PropertyReportHandler.java
+++ b/src/main/java/org/hanihome/hanihomebe/report/application/PropertyReportHandler.java
@@ -45,7 +45,7 @@ public class PropertyReportHandler implements ReportHandler {
     }
 
     @Override
-    public void delete(Long targetId) {
-        propertyReportRepository.deleteById(targetId);
+    public void deleteByTargetId(Long targetId) {
+        propertyReportRepository.deleteByProperty_Id(targetId);
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/report/application/ReportHandler.java
+++ b/src/main/java/org/hanihome/hanihomebe/report/application/ReportHandler.java
@@ -9,5 +9,5 @@ public interface ReportHandler {
     ReportTargetType getTargetType();
     Report createAndSave(Member reporter, ReportRequestDTO dto);
     boolean validate(ReportRequestDTO dto);
-    void delete(Long targetId);
+    void deleteByTargetId(Long targetId);
 }

--- a/src/main/java/org/hanihome/hanihomebe/report/repository/PropertyReportRepository.java
+++ b/src/main/java/org/hanihome/hanihomebe/report/repository/PropertyReportRepository.java
@@ -4,4 +4,5 @@ import org.hanihome.hanihomebe.report.application.domain.PropertyReport;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PropertyReportRepository extends JpaRepository<PropertyReport, Long> {
+    void deleteByProperty_Id(Long propertyId);
 }

--- a/src/main/java/org/hanihome/hanihomebe/report/service/ReportService.java
+++ b/src/main/java/org/hanihome/hanihomebe/report/service/ReportService.java
@@ -57,10 +57,6 @@ public class ReportService {
 
     //관리자 조회
 
-    public List<ReportResponseDTO> getReports(ReportTargetType targetType) {
-
-    }
-
     @Transactional
     public void delete(Long targetId, ReportTargetType targetType) {
         ReportHandler handler = reportHandlerMap.get(targetType);

--- a/src/main/java/org/hanihome/hanihomebe/report/service/ReportService.java
+++ b/src/main/java/org/hanihome/hanihomebe/report/service/ReportService.java
@@ -57,10 +57,14 @@ public class ReportService {
 
     //관리자 조회
 
+    public List<ReportResponseDTO> getReports(ReportTargetType targetType) {
+
+    }
+
     @Transactional
     public void delete(Long targetId, ReportTargetType targetType) {
         ReportHandler handler = reportHandlerMap.get(targetType);
-        handler.delete(targetId);
+        handler.deleteByTargetId(targetId);
     }
 
 }


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
연관 엔티티인 ProeprtyReport를 삭제할 때 propertyId를 기준으로 삭제해야하는데 PropertyReportId를 기준으로 삭제했기에 targetId기준으로 삭제하도록 변경

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
