### PR TITLE
[REFACTOR] 매물 삭제 - 연관 엔티티 삭제 로직 중 Deal 추가

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/deal/repository/DealRepository.java
+++ b/src/main/java/org/hanihome/hanihomebe/deal/repository/DealRepository.java
@@ -11,4 +11,6 @@ public interface DealRepository extends JpaRepository<Deal, Long> {
     List<Deal> findByGuest_Id(Long guestId);
 
     List<Deal> findByHost_Id(Long hostId);
+
+    void deleteByProperty_Id(Long propertyId);
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyService.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyService.java
@@ -3,13 +3,13 @@ package org.hanihome.hanihomebe.property.application.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hanihome.hanihomebe.deal.application.service.DealService;
+import org.hanihome.hanihomebe.deal.repository.DealRepository;
 import org.hanihome.hanihomebe.global.exception.CustomException;
 import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.global.utility.SecurityContextUtils;
 import org.hanihome.hanihomebe.member.domain.Member;
 import org.hanihome.hanihomebe.member.repository.MemberRepository;
 import org.hanihome.hanihomebe.metro.application.service.NearestMetroStopService;
-import org.hanihome.hanihomebe.metro.repository.NearestMetroStopRepository;
 import org.hanihome.hanihomebe.property.application.factory.PropertyFactory;
 import org.hanihome.hanihomebe.property.domain.Property;
 import org.hanihome.hanihomebe.item.domain.OptionItem;
@@ -32,7 +32,6 @@ import org.hanihome.hanihomebe.viewing.domain.ViewingStatus;
 import org.hanihome.hanihomebe.viewing.repository.ViewingRepository;
 import org.hanihome.hanihomebe.wishlist.domain.enums.WishTargetType;
 import org.hanihome.hanihomebe.wishlist.repository.WishItemRepository;
-import org.springdoc.webmvc.core.service.RequestService;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +57,7 @@ public class PropertyService {
     private final ViewingService viewingService;
     private final ViewingRepository viewingRepository;
     private final ReportService reportService;
+    private final DealRepository dealRepository;
 
 
     /// create
@@ -230,6 +230,7 @@ public class PropertyService {
         }
         wishItemRepository.deleteAllByTargetTypeAndTargetId(WishTargetType.PROPERTY, id); //해당 찜하기 삭제
         viewingRepository.deleteByProperty_Id(id);
+        dealRepository.deleteByProperty_Id(id);
         nearestMetroStopService.deleteByPropertyId(id);
         reportService.delete(id, ReportTargetType.PROPERTY);
 

--- a/src/main/java/org/hanihome/hanihomebe/viewing/application/service/ViewingService.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/application/service/ViewingService.java
@@ -53,7 +53,6 @@ public class ViewingService {
     private final OptionItemRepository optionItemRepository;
     private final OptionCategoryRepository optionCategoryRepository;
     private final ViewingConversionService viewingConversionService;
-    private final OptionItemConverterForViewing optionItemConverterForViewing;
 
     /**
      * 뷰잉 생성


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
매물 삭제 시 연관된 Deal도 삭제하겠습니다.

## 📚 Reference
- [x] 현재 매물 엔티티를 삭제하는 로직에서 매물 엔티티를 참조하는 다른 엔티티 때문에 FK제약조건 위배로 인해서 proeprtyservice.delete()함수에서 연관된 엔티티를 모두 삭제해야하는 일을 하고있네요. 그리고 연관관계를 모두 파악하기가 쉽지 않아서 매번 PR을 올리고 있고.. 굉장히 문제가 많아보입니다..

### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
