### PR TITLE
[FIX]#224 total floor 필드가 Null인 매물 조회시 conversion 오류 해결

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/property/domain/Property.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/domain/Property.java
@@ -178,6 +178,7 @@ public abstract class Property {
     /**
      * 16. 매물 소개
      */
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     /**

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/PropertySummaryDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/PropertySummaryDTO.java
@@ -30,7 +30,7 @@ public sealed interface PropertySummaryDTO
 
     Double internalArea();
 
-    int totalFloors();
+    Integer totalFloors();
 
     boolean billIncluded();
 

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/RentPropertySummaryDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/RentPropertySummaryDTO.java
@@ -17,7 +17,7 @@ public record RentPropertySummaryDTO(
         BigDecimal weeklyCost,
         String suburb,
         Double internalArea,
-        int totalFloors,
+        Integer totalFloors,
         boolean billIncluded,
         NearestMetroStopResponseDTO nearestStation,
         String thumbnailUrl,

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/SharePropertySummaryDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/summary/SharePropertySummaryDTO.java
@@ -5,7 +5,6 @@ import org.hanihome.hanihomebe.metro.web.dto.nearest.NearestMetroStopResponseDTO
 import org.hanihome.hanihomebe.property.domain.enums.PropertySuperType;
 import org.hanihome.hanihomebe.property.domain.enums.SharePropertySubType;
 import org.hanihome.hanihomebe.property.domain.enums.TradeStatus;
-import org.hanihome.hanihomebe.property.web.dto.response.PropertyDTOByView;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -17,7 +16,7 @@ public record SharePropertySummaryDTO(
         BigDecimal weeklyCost,
         String suburb,
         Double internalArea,
-        int totalFloors,
+        Integer totalFloors,
         boolean billIncluded,
         NearestMetroStopResponseDTO nearestStation,
         String thumbnailUrl,


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #224 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
반환 DTO에서 int -> Integer 타입으로 변경

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
