### PR TITLE
[FIX]#226 매물 수정 - PropertyPatchDTO에서 PatchCommand로 변환할 때 NPE 예외 발생

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/patch/RentPropertyPatchRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/patch/RentPropertyPatchRequestDTO.java
@@ -9,6 +9,9 @@ import org.hanihome.hanihomebe.property.domain.command.RentPropertyPatchCommand;
 import org.hanihome.hanihomebe.property.domain.enums.CapacityRent;
 import org.hanihome.hanihomebe.property.domain.enums.RentPropertySubType;
 import org.hanihome.hanihomebe.property.domain.item.PropertyOptionItem;
+import org.hanihome.hanihomebe.property.web.dto.request.create.CostDetailsDTO;
+import org.hanihome.hanihomebe.property.web.dto.request.create.LivingConditionsDTO;
+import org.hanihome.hanihomebe.property.web.dto.request.create.MoveInInfoDTO;
 import org.hanihome.hanihomebe.property.web.dto.request.create.RentInternalDetailsDTO;
 
 import java.util.List;
@@ -34,6 +37,10 @@ public class RentPropertyPatchRequestDTO extends PropertyPatchRequestDTO {
 
     @Override
     public PropertyPatchCommand toCommand(List<PropertyOptionItem> propertyOptionItems) {
+        LivingConditionsDTO livingConditionsDTO = super.getLivingConditions();
+        MoveInInfoDTO moveInInfoDTO = super.getMoveInInfo();
+        CostDetailsDTO costDetailsDTO = super.getCostDetails();
+        RentInternalDetailsDTO rentInternalDetailsDTO = this.internalDetails;
         return RentPropertyPatchCommand.builder()
                 // 공통 필드
                 .genderPreference(super.getGenderPreference())
@@ -41,9 +48,9 @@ public class RentPropertyPatchRequestDTO extends PropertyPatchRequestDTO {
                 .region(super.getRegion())
                 .photoUrls(super.getPhotoUrls())
                 .optionItems(propertyOptionItems)
-                .costDetails(super.getCostDetails().toVO())
-                .livingConditions(super.getLivingConditions().toVO())
-                .moveInInfo(super.getMoveInInfo().toVO())
+                .costDetails(costDetailsDTO != null ? costDetailsDTO.toVO() : null)
+                .livingConditions(livingConditionsDTO != null ? livingConditionsDTO.toVO() : null)
+                .moveInInfo(moveInInfoDTO != null ? moveInInfoDTO.toVO() : null)
                 .meetingDateFrom(super.getMeetingDateFrom())
                 .meetingDateTo(super.getMeetingDateTo())
                 .timeSlots(super.getTimeSlots())
@@ -53,7 +60,7 @@ public class RentPropertyPatchRequestDTO extends PropertyPatchRequestDTO {
 
                 // RentProperty 전용 필드
                 .rentPropertySubType(this.rentPropertySubType)
-                .internalDetails(this.internalDetails.toVO())
+                .internalDetails(rentInternalDetailsDTO != null ? rentInternalDetailsDTO.toVO() : null)
                 .capacityRent(this.capacityRent)
                 .build();
     }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/patch/SharePropertyPatchRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/patch/SharePropertyPatchRequestDTO.java
@@ -9,6 +9,9 @@ import org.hanihome.hanihomebe.property.domain.command.SharePropertyPatchCommand
 import org.hanihome.hanihomebe.property.domain.enums.CapacityShare;
 import org.hanihome.hanihomebe.property.domain.enums.SharePropertySubType;
 import org.hanihome.hanihomebe.property.domain.item.PropertyOptionItem;
+import org.hanihome.hanihomebe.property.web.dto.request.create.CostDetailsDTO;
+import org.hanihome.hanihomebe.property.web.dto.request.create.LivingConditionsDTO;
+import org.hanihome.hanihomebe.property.web.dto.request.create.MoveInInfoDTO;
 import org.hanihome.hanihomebe.property.web.dto.request.create.ShareInternalDetailsDTO;
 
 import java.util.List;
@@ -31,6 +34,9 @@ public class SharePropertyPatchRequestDTO extends PropertyPatchRequestDTO {
 
     @Override
     public PropertyPatchCommand toCommand(List<PropertyOptionItem> propertyOptionItems) {
+        CostDetailsDTO costDetailsDTO = super.getCostDetails();
+        LivingConditionsDTO livingConditionsDTO = super.getLivingConditions();
+        MoveInInfoDTO moveInInfoDTO = super.getMoveInInfo();
         return SharePropertyPatchCommand.builder()
                 // 공통 필드
                 .genderPreference(super.getGenderPreference())
@@ -38,9 +44,9 @@ public class SharePropertyPatchRequestDTO extends PropertyPatchRequestDTO {
                 .region(super.getRegion())
                 .photoUrls(super.getPhotoUrls())
                 .optionItems(propertyOptionItems)
-                .costDetails(super.getCostDetails().toVO())
-                .livingConditions(super.getLivingConditions().toVO())
-                .moveInInfo(super.getMoveInInfo().toVO())
+                .costDetails(costDetailsDTO != null ? costDetailsDTO.toVO() : null)
+                .livingConditions(livingConditionsDTO != null ? livingConditionsDTO.toVO() : null)
+                .moveInInfo(moveInInfoDTO != null ? moveInInfoDTO.toVO() : null)
                 .meetingDateFrom(super.getMeetingDateFrom())
                 .meetingDateTo(super.getMeetingDateTo())
                 .timeSlots(super.getTimeSlots())
@@ -50,7 +56,7 @@ public class SharePropertyPatchRequestDTO extends PropertyPatchRequestDTO {
 
                 // ShareProperty 전용 필드
                 .sharePropertySubType(this.sharePropertySubType)
-                .internalDetails(this.internalDetails.toVO())
+                .internalDetails(this.internalDetails != null ? this.internalDetails.toVO() : null)
                 .capacityShare(this.capacityShare)
                 .build();
     }


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #226 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 문제: PatchDTO에서 Command로 변환하는 과정에서 VO에 대해서 문제가 발생했음.
- 해결: VO의 DTO가 null인 경우는 VO로 변환하지 않고 null을 넣도록 수정하였음.

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
