### PR TITLE
[FEAT]#230 알림 종류 추가 - 매물의 뷰잉 예약기간 24/48시간 전

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/admin/customerservice/application/OneOnOneNotificationService.java
+++ b/src/main/java/org/hanihome/hanihomebe/admin/customerservice/application/OneOnOneNotificationService.java
@@ -2,7 +2,7 @@ package org.hanihome.hanihomebe.admin.customerservice.application;
 
 import lombok.RequiredArgsConstructor;
 import org.hanihome.hanihomebe.notification.application.service.NotificationFacadeService;
-import org.hanihome.hanihomebe.notification.application.service.NotificationMessageFactory;
+import org.hanihome.hanihomebe.notification.application.service.factory.NotificationMessageFactory;
 import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +13,7 @@ public class OneOnOneNotificationService {
     private final NotificationMessageFactory messageFactory;
 
     public void sendOneOnOneConsultRepliedNotification(Long customerId) {
-        NotificationCreateDTO message = messageFactory.createOneOnOneConsultRepliedMessage(customerId);
+        NotificationCreateDTO message = messageFactory.getOneOnOneConsultMessageCreator().createOneOnOneConsultRepliedMessage(customerId);
         notificationFacadeService.sendNotification(message);
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/admin/customerservice/web/controller/OneOnOneController.java
+++ b/src/main/java/org/hanihome/hanihomebe/admin/customerservice/web/controller/OneOnOneController.java
@@ -7,9 +7,6 @@ import org.hanihome.hanihomebe.admin.customerservice.domain.OneOnOneConsultStatu
 import org.hanihome.hanihomebe.admin.customerservice.web.dto.OneOnOneConsultCreateDTO;
 import org.hanihome.hanihomebe.admin.customerservice.web.dto.OneOnOneConsultReplyDTO;
 import org.hanihome.hanihomebe.admin.customerservice.web.dto.OneOnOneConsultResponseDTO;
-import org.hanihome.hanihomebe.notification.application.service.NotificationFacadeService;
-import org.hanihome.hanihomebe.notification.application.service.NotificationMessageFactory;
-import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
 import org.hanihome.hanihomebe.security.auth.user.detail.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -21,8 +18,6 @@ import java.util.List;
 @RestController
 public class OneOnOneController {
     private final OneOnOneService oneOnOneService;
-    private final NotificationFacadeService notificationFacadeService;
-    private final NotificationMessageFactory messageFactory;
     private final OneOnOneNotificationService oneOnOneNotificationService;
 
     // 상담 등록

--- a/src/main/java/org/hanihome/hanihomebe/global/aop/notification/NotificationSchedulerLoggingAspect.java
+++ b/src/main/java/org/hanihome/hanihomebe/global/aop/notification/NotificationSchedulerLoggingAspect.java
@@ -1,0 +1,43 @@
+package org.hanihome.hanihomebe.global.aop.notification;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.hanihome.hanihomebe.notification.domain.Notification;
+import org.hanihome.hanihomebe.notification.domain.TaskType;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class NotificationSchedulerLoggingAspect {
+
+    @Pointcut("execution(* org.hanihome.hanihomebe.notification.application.service.TaskReminderScheduler.scheduleReminder(..))")
+    public void schedulePointcut() {}
+
+    @Pointcut("execution(* org.hanihome.hanihomebe.notification.application.service.TaskReminderScheduler.cancelTask(..))")
+    public void cancelPointcut() {}
+
+    @Before("schedulePointcut()")
+    public void logBeforeSchedule(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        if (args.length >= 3) {
+            Class<?> entityClass = Notification.class;
+            Long entityId = (Long) args[0];
+            String taskType = String.valueOf((TaskType) args[2]);
+            String rawKey = entityClass.getSimpleName() + "_" + entityId + "_" + taskType;
+
+            log.info("[TaskReminderScheduler] 작업 등록 - {}", rawKey);
+        }
+    }
+
+    @Before("cancelPointcut()")
+    public void logBeforeCancel(JoinPoint joinPoint) {
+        if (joinPoint.getArgs().length >= 1) {
+            String uuidKey = (String) joinPoint.getArgs()[0];
+            log.info("[TaskReminderScheduler] 작업 취소 - UUIDKey={}", uuidKey);
+        }
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationFacadeService.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationFacadeService.java
@@ -19,7 +19,8 @@ public class NotificationFacadeService {
     // 컨트롤러에는 서비스 조합을 단순하게 노출시켜 하나의 진입점으로 만든다.
     private final NotificationService notificationService;
     private final NotificationPushService notificationPushService;
-    private final ViewingReminderScheduler viewingReminderScheduler;
+    private final TaskReminderScheduler taskReminderScheduler;
+
 
     public void sendNotification(NotificationCreateDTO dto) {
         // 알림 생성
@@ -35,14 +36,6 @@ public class NotificationFacadeService {
         // 알림생성
         Long notificationId = notificationService.createNotification(dto).id();
         // 알림전송 스케줄링
-        viewingReminderScheduler.scheduleReminder(notificationId, triggerTime);
+        taskReminderScheduler.scheduleReminder(notificationId, triggerTime);
     }
-    /*
-    public void markAllAsRead(Long userId) {
-        notificationService.markAllAsRead(userId);
-        notificationPushService.pushNotification(userId, null);
-    }
-    public void deleteNotification(Long notificationId) {
-        notificationService.deleteNotification(notificationId);
-    }*/
 }

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationFacadeService.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/NotificationFacadeService.java
@@ -2,6 +2,7 @@ package org.hanihome.hanihomebe.notification.application.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hanihome.hanihomebe.notification.domain.TaskType;
 import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
 import org.springframework.stereotype.Service;
 
@@ -31,11 +32,11 @@ public class NotificationFacadeService {
         notificationPushService.pushNotification(notificationId);
     }
 
-    // 3. 24시간 전 리마인더 알림 등록
-    public void registerReminderNotification(NotificationCreateDTO dto, LocalDateTime triggerTime) {
+    // 3. xx시간 전 리마인더 알림 등록
+    public void registerReminderNotification(NotificationCreateDTO dto, LocalDateTime triggerTime , TaskType taskType) {
         // 알림생성
         Long notificationId = notificationService.createNotification(dto).id();
         // 알림전송 스케줄링
-        taskReminderScheduler.scheduleReminder(notificationId, triggerTime);
+        taskReminderScheduler.scheduleReminder(notificationId, triggerTime, taskType);
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/TaskReminderScheduler.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/TaskReminderScheduler.java
@@ -1,20 +1,17 @@
 package org.hanihome.hanihomebe.notification.application.service;
 
 import lombok.RequiredArgsConstructor;
-import org.hanihome.hanihomebe.viewing.application.service.ViewingService;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Date;
 
 @RequiredArgsConstructor
 @Service
-public class ViewingReminderScheduler {
+public class TaskReminderScheduler {
     private final NotificationPushService notificationPushService;
     private final TaskScheduler taskScheduler;
 

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/TaskReminderScheduler.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/TaskReminderScheduler.java
@@ -1,21 +1,29 @@
 package org.hanihome.hanihomebe.notification.application.service;
 
 import lombok.RequiredArgsConstructor;
+import org.hanihome.hanihomebe.notification.domain.Notification;
+import org.hanihome.hanihomebe.notification.domain.TaskType;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 
 @RequiredArgsConstructor
 @Service
 public class TaskReminderScheduler {
     private final NotificationPushService notificationPushService;
     private final TaskScheduler taskScheduler;
+    private final Map<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
 
-    public void scheduleReminder(Long notificationId,LocalDateTime triggerTime) {
+    public void scheduleReminder(Long notificationId, LocalDateTime triggerTime, TaskType taskType) {
         Instant triggerInstant = triggerTime.atOffset(ZoneOffset.UTC).toInstant();
         // 미팅이 24시간 미만으로 남았을 경우 즉시 전송
         if (!triggerInstant.isAfter(Instant.now())) {
@@ -23,8 +31,34 @@ public class TaskReminderScheduler {
         }
         // task scheduling
         else {
+            String rawKey = generateRawKey(notificationId, taskType);
+            String uuidKey= toUUID(rawKey);
+
+            cancelTask(uuidKey);
+
             Date triggerDate = Date.from(triggerInstant);
-            taskScheduler.schedule(() -> notificationPushService.pushNotification(notificationId), triggerDate);
+            Runnable task = () -> {
+                notificationPushService.pushNotification(notificationId);
+                scheduledTasks.remove(uuidKey);
+            };
+            ScheduledFuture<?> scheduledFuture = taskScheduler.schedule(task, triggerDate);
+
+            scheduledTasks.put(uuidKey, scheduledFuture);
         }
+    }
+
+    public void cancelTask(String uuidKey) {
+        ScheduledFuture<?> scheduledFuture = scheduledTasks.remove(uuidKey);
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(false);
+        }
+    }
+
+    private static String toUUID(String rawKey) {
+        return UUID.nameUUIDFromBytes(rawKey.getBytes(StandardCharsets.UTF_8)).toString();
+    }
+
+    private static String generateRawKey(Long notificationId, TaskType taskType) {
+        return Notification.class.getSimpleName() + "_" + String.valueOf(notificationId) + "_" + taskType;
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/NotificationMessageFactory.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/NotificationMessageFactory.java
@@ -1,0 +1,30 @@
+package org.hanihome.hanihomebe.notification.application.service.factory;
+
+import lombok.RequiredArgsConstructor;
+import org.hanihome.hanihomebe.notification.application.service.factory.creator.OneOnOneConsultNotificationMessageCreator;
+import org.hanihome.hanihomebe.notification.application.service.factory.creator.PropertyNotificationMessageCreator;
+import org.hanihome.hanihomebe.notification.application.service.factory.creator.VerificationNotificationMessageCreator;
+import org.hanihome.hanihomebe.notification.application.service.factory.creator.ViewingNotificationMessageCreator;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class NotificationMessageFactory {
+    private final ViewingNotificationMessageCreator viewingNotificationMessageCreator;
+    private final VerificationNotificationMessageCreator verificationNotificationMessageCreator;
+    private final OneOnOneConsultNotificationMessageCreator oneOnOneConsultNotificationMessageCreator;
+    private final PropertyNotificationMessageCreator propertyNotificationMessageCreator;
+
+    public ViewingNotificationMessageCreator getViewingMessageCreator() {
+        return viewingNotificationMessageCreator;
+    }
+    public VerificationNotificationMessageCreator getVerificationMessageCreator() {
+        return verificationNotificationMessageCreator;
+    }
+    public OneOnOneConsultNotificationMessageCreator getOneOnOneConsultMessageCreator() {
+        return oneOnOneConsultNotificationMessageCreator;
+    }
+    public PropertyNotificationMessageCreator getPRopertyMessageCreator() {
+        return propertyNotificationMessageCreator;
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/creator/NotificationMessageCreator.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/creator/NotificationMessageCreator.java
@@ -1,0 +1,4 @@
+package org.hanihome.hanihomebe.notification.application.service.factory.creator;
+
+public interface NotificationMessageCreator {
+}

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/creator/OneOnOneConsultNotificationMessageCreator.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/creator/OneOnOneConsultNotificationMessageCreator.java
@@ -1,0 +1,15 @@
+package org.hanihome.hanihomebe.notification.application.service.factory.creator;
+
+import org.hanihome.hanihomebe.notification.domain.NotificationType;
+import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OneOnOneConsultNotificationMessageCreator implements NotificationMessageCreator{
+    /// one on one consult
+    public NotificationCreateDTO createOneOnOneConsultRepliedMessage(Long receiverId) {
+        String title = "1:1 문의에 대한 답변이 완료되었어요";
+        String content = "이메일로 확인해주세요";
+        return NotificationCreateDTO.create(receiverId, title, content, NotificationType.ONE_ON_ONE_CONSULT_REPLIED);
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/creator/PropertyNotificationMessageCreator.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/creator/PropertyNotificationMessageCreator.java
@@ -1,0 +1,22 @@
+package org.hanihome.hanihomebe.notification.application.service.factory.creator;
+
+import lombok.RequiredArgsConstructor;
+import org.hanihome.hanihomebe.notification.domain.NotificationType;
+import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PropertyNotificationMessageCreator {
+    public NotificationCreateDTO createMeetingDateReminderBefore48h(Long hostId) {
+        String title = "뷰잉 예약 기간이 이틀 후에 종료돼요";
+        String content = "게스트를 찾지 못했다면 기간을 연장하거나 정보를 수정해보세요";
+        NotificationType type = NotificationType.PROPERTY;
+        return NotificationCreateDTO.create(hostId, title, content, type);
+    }
+    public NotificationCreateDTO createMeetingDateReminderBefore24h(Long hostId) {
+        String title = "뷰잉 예약 기간이 내일 종료돼요";
+        String content = "게스트를 찾지 못했다면 기간을 연장하거나 정보를 수정해보세요";
+        NotificationType type = NotificationType.PROPERTY;
+        return NotificationCreateDTO.create(hostId, title, content, type);
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/creator/VerificationNotificationMessageCreator.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/creator/VerificationNotificationMessageCreator.java
@@ -1,0 +1,28 @@
+package org.hanihome.hanihomebe.notification.application.service.factory.creator;
+
+import lombok.RequiredArgsConstructor;
+import org.hanihome.hanihomebe.notification.domain.NotificationType;
+import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
+import org.hanihome.hanihomebe.verification.service.VerificationService;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class VerificationNotificationMessageCreator implements NotificationMessageCreator{
+    private final VerificationService verificationService;
+
+    /// Verification
+    public NotificationCreateDTO createVerificationApproveMessage(Long verificationId) {
+        String title = "신원 인증 검수가 완료되었습니다";
+        String content = "신원 인증에 성공했습니다";
+        Long receiverId = verificationService.getVerificationById(verificationId).getMemberId();
+        return NotificationCreateDTO.create(receiverId, title, content, NotificationType.VERIFICATION_CHECKED);
+    }
+
+    public NotificationCreateDTO createVerificationRejectMessage(Long verificationId, String reason) {
+        String title = "신원 인증 검수가 완료되었습니다";
+        String content = "아래와 같은 이유로 신원 인증에 실패했습니다 \n"+reason;
+        Long receiverId = verificationService.getVerificationById(verificationId).getMemberId();
+        return NotificationCreateDTO.create(receiverId, title, content, NotificationType.VERIFICATION_CHECKED);
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/creator/ViewingNotificationMessageCreator.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/factory/creator/ViewingNotificationMessageCreator.java
@@ -1,10 +1,9 @@
-package org.hanihome.hanihomebe.notification.application.service;
+package org.hanihome.hanihomebe.notification.application.service.factory.creator;
 
 import lombok.RequiredArgsConstructor;
 import org.hanihome.hanihomebe.notification.domain.NotificationType;
 import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
 import org.hanihome.hanihomebe.property.application.service.PropertyService;
-import org.hanihome.hanihomebe.verification.service.VerificationService;
 import org.hanihome.hanihomebe.viewing.application.service.ViewingService;
 import org.hanihome.hanihomebe.viewing.web.dto.ViewingResponseDTO;
 import org.springframework.stereotype.Component;
@@ -15,11 +14,11 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Component
-public class NotificationMessageFactory {
+public class ViewingNotificationMessageCreator implements NotificationMessageCreator {
     private final ViewingService viewingService;
     private final PropertyService propertyService;
-    private final VerificationService verificationService;
 
+    /// viewing
     public NotificationCreateDTO createViewingCanceledMessage(Long actorId, Long viewingId) {
         ViewingResponseDTO findViewing = viewingService.getViewingById(viewingId);
         Long guestId = findViewing.getGuestId();
@@ -69,23 +68,4 @@ public class NotificationMessageFactory {
         return List.of(guestDTO, hostDTO);
     }
 
-    public NotificationCreateDTO createOneOnOneConsultRepliedMessage(Long receiverId) {
-        String title = "1:1 문의에 대한 답변이 완료되었어요";
-        String content = "이메일로 확인해주세요";
-        return NotificationCreateDTO.create(receiverId, title, content, NotificationType.ONE_ON_ONE_CONSULT_REPLIED);
-    }
-
-    public NotificationCreateDTO createVerificationApproveMessage(Long verificationId) {
-        String title = "신원 인증 검수가 완료되었습니다";
-        String content = "신원 인증에 성공했습니다";
-        Long receiverId = verificationService.getVerificationById(verificationId).getMemberId();
-        return NotificationCreateDTO.create(receiverId, title, content, NotificationType.VERIFICATION_CHECKED);
-    }
-
-    public NotificationCreateDTO createVerificationRejectMessage(Long verificationId, String reason) {
-        String title = "신원 인증 검수가 완료되었습니다";
-        String content = "아래와 같은 이유로 신원 인증에 실패했습니다 \n"+reason;
-        Long receiverId = verificationService.getVerificationById(verificationId).getMemberId();
-        return NotificationCreateDTO.create(receiverId, title, content, NotificationType.VERIFICATION_CHECKED);
-    }
 }

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/property/PropertyNotificationService.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/property/PropertyNotificationService.java
@@ -3,9 +3,11 @@ package org.hanihome.hanihomebe.notification.application.service.property;
 import lombok.RequiredArgsConstructor;
 import org.hanihome.hanihomebe.notification.application.service.NotificationFacadeService;
 import org.hanihome.hanihomebe.notification.application.service.factory.NotificationMessageFactory;
+import org.hanihome.hanihomebe.notification.domain.TaskType;
 import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
@@ -14,19 +16,21 @@ public class PropertyNotificationService {
     private final NotificationFacadeService notificationFacadeService;
     private final NotificationMessageFactory messageFactory;
 
-    public void registerReminderNotification(Long hostId, LocalDateTime meetingDateTo) {
+    public void registerMeetingDateReminderNotification(Long hostId, LocalDate meetingDateTo) {
         registerMeetingDateToReminderBefore24h(hostId, meetingDateTo);
         registerMeetingDateToReminderBefore48h(hostId, meetingDateTo);
     }
 
-    private void registerMeetingDateToReminderBefore24h(Long hostId, LocalDateTime meetingDateTo) {
+    private void registerMeetingDateToReminderBefore24h(Long hostId, LocalDate meetingDateTo) {
         NotificationCreateDTO message = messageFactory.getPRopertyMessageCreator().createMeetingDateReminderBefore24h(hostId);
-        LocalDateTime triggerTime = meetingDateTo.minusHours(24);
-        notificationFacadeService.registerReminderNotification(message, triggerTime);
+        LocalDateTime triggerTime = meetingDateTo.atStartOfDay().minusHours(24);
+        TaskType taskType = TaskType.PROPERTY_MEETING_DATE_REMINDER_BEFORE_24;
+        notificationFacadeService.registerReminderNotification(message, triggerTime, taskType);
     }
-    private void registerMeetingDateToReminderBefore48h(Long hostId, LocalDateTime meetingDateTo) {
+    private void registerMeetingDateToReminderBefore48h(Long hostId, LocalDate meetingDateTo) {
         NotificationCreateDTO message = messageFactory.getPRopertyMessageCreator().createMeetingDateReminderBefore24h(hostId);
-        LocalDateTime triggerTime = meetingDateTo.minusHours(48);
-        notificationFacadeService.registerReminderNotification(message, triggerTime);
+        LocalDateTime triggerTime = meetingDateTo.atStartOfDay().minusHours(48);
+        TaskType taskType = TaskType.PROPERTY_MEETING_DATE_REMINDER_BEFORE_48;
+        notificationFacadeService.registerReminderNotification(message, triggerTime, taskType);
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/property/PropertyNotificationService.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/property/PropertyNotificationService.java
@@ -1,0 +1,32 @@
+package org.hanihome.hanihomebe.notification.application.service.property;
+
+import lombok.RequiredArgsConstructor;
+import org.hanihome.hanihomebe.notification.application.service.NotificationFacadeService;
+import org.hanihome.hanihomebe.notification.application.service.factory.NotificationMessageFactory;
+import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class PropertyNotificationService {
+    private final NotificationFacadeService notificationFacadeService;
+    private final NotificationMessageFactory messageFactory;
+
+    public void registerReminderNotification(Long hostId, LocalDateTime meetingDateTo) {
+        registerMeetingDateToReminderBefore24h(hostId, meetingDateTo);
+        registerMeetingDateToReminderBefore48h(hostId, meetingDateTo);
+    }
+
+    private void registerMeetingDateToReminderBefore24h(Long hostId, LocalDateTime meetingDateTo) {
+        NotificationCreateDTO message = messageFactory.getPRopertyMessageCreator().createMeetingDateReminderBefore24h(hostId);
+        LocalDateTime triggerTime = meetingDateTo.minusHours(24);
+        notificationFacadeService.registerReminderNotification(message, triggerTime);
+    }
+    private void registerMeetingDateToReminderBefore48h(Long hostId, LocalDateTime meetingDateTo) {
+        NotificationCreateDTO message = messageFactory.getPRopertyMessageCreator().createMeetingDateReminderBefore24h(hostId);
+        LocalDateTime triggerTime = meetingDateTo.minusHours(48);
+        notificationFacadeService.registerReminderNotification(message, triggerTime);
+    }
+}

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/viewing/ViewingNotificationService.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/viewing/ViewingNotificationService.java
@@ -1,8 +1,8 @@
-package org.hanihome.hanihomebe.viewing.application.service;
+package org.hanihome.hanihomebe.notification.application.service.viewing;
 
 import lombok.RequiredArgsConstructor;
 import org.hanihome.hanihomebe.notification.application.service.NotificationFacadeService;
-import org.hanihome.hanihomebe.notification.application.service.NotificationMessageFactory;
+import org.hanihome.hanihomebe.notification.application.service.factory.NotificationMessageFactory;
 import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
 import org.springframework.stereotype.Service;
 
@@ -17,17 +17,17 @@ public class ViewingNotificationService {
 
 
     public void sendViewingCanceledNotification(Long actorId, Long viewingId) {
-        NotificationCreateDTO message = messageFactory.createViewingCanceledMessage(actorId, viewingId);
+        NotificationCreateDTO message = messageFactory.getViewingMessageCreator().createViewingCanceledMessage(actorId, viewingId);
         notificationFacadeService.sendNotification(message);
     }
 
     public void sendViewingCreateNotification(String actorName, Long viewingId) {
-        NotificationCreateDTO message = messageFactory.createViewingCreateMessage(actorName, viewingId);
+        NotificationCreateDTO message = messageFactory.getViewingMessageCreator().createViewingCreateMessage(actorName, viewingId);
         notificationFacadeService.sendNotification(message);
     }
 
-    public void sendReminderNotification(Long viewingId, LocalDateTime meetingDay) {
-        List<NotificationCreateDTO> reminderNotifications = messageFactory.createViewingReminderMessage(viewingId);
+    public void registerReminderNotification(Long viewingId, LocalDateTime meetingDay) {
+        List<NotificationCreateDTO> reminderNotifications = messageFactory.getViewingMessageCreator().createViewingReminderMessage(viewingId);
         LocalDateTime triggerTime = meetingDay.minusHours(24);
         reminderNotifications.forEach(
                 reminder->notificationFacadeService.registerReminderNotification(reminder, triggerTime)

--- a/src/main/java/org/hanihome/hanihomebe/notification/application/service/viewing/ViewingNotificationService.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/application/service/viewing/ViewingNotificationService.java
@@ -3,6 +3,7 @@ package org.hanihome.hanihomebe.notification.application.service.viewing;
 import lombok.RequiredArgsConstructor;
 import org.hanihome.hanihomebe.notification.application.service.NotificationFacadeService;
 import org.hanihome.hanihomebe.notification.application.service.factory.NotificationMessageFactory;
+import org.hanihome.hanihomebe.notification.domain.TaskType;
 import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
 import org.springframework.stereotype.Service;
 
@@ -30,7 +31,7 @@ public class ViewingNotificationService {
         List<NotificationCreateDTO> reminderNotifications = messageFactory.getViewingMessageCreator().createViewingReminderMessage(viewingId);
         LocalDateTime triggerTime = meetingDay.minusHours(24);
         reminderNotifications.forEach(
-                reminder->notificationFacadeService.registerReminderNotification(reminder, triggerTime)
+                reminder->notificationFacadeService.registerReminderNotification(reminder, triggerTime, TaskType.VIEWING_REMINDER)
         );
     }
 

--- a/src/main/java/org/hanihome/hanihomebe/notification/domain/Notification.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/domain/Notification.java
@@ -32,6 +32,7 @@ public class Notification extends BaseEntity {
     private NotificationSendStatus notificationSendStatus; // 조회 시 sendStatus가 SUCCESS인 것만 조회되어야한다.
 
     @Enumerated(EnumType.STRING)
+    @Column(length = 50)
     private NotificationType type; // VIEWING_REMINDER, VIEWING_CREATED, VIEWING_CANCELED
 
     public static Notification create(Member receiver, String title, String content, NotificationType type) {

--- a/src/main/java/org/hanihome/hanihomebe/notification/domain/NotificationType.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/domain/NotificationType.java
@@ -10,6 +10,7 @@ public enum NotificationType {
     VIEWING_CANCELED("뷰잉 취소 알림"),
     ONE_ON_ONE_CONSULT_REPLIED("일대일 상담 답변 완료 알림"),
     VERIFICATION_CHECKED("신원 인증 검수 완료 알림"),
+    PROPERTY("매물 알림")
     ;
     private final String description;
 }

--- a/src/main/java/org/hanihome/hanihomebe/notification/domain/TaskType.java
+++ b/src/main/java/org/hanihome/hanihomebe/notification/domain/TaskType.java
@@ -1,0 +1,18 @@
+package org.hanihome.hanihomebe.notification.domain;
+
+import lombok.RequiredArgsConstructor;
+
+/// Event name
+@RequiredArgsConstructor
+public enum TaskType {
+    VIEWING_REMINDER("뷰잉 24시간전 리마인드"),
+    VIEWING_CREATED("뷰잉 생성 알림"),
+    VIEWING_CANCELED("뷰잉 취소 알림"),
+    ONE_ON_ONE_CONSULT_REPLIED("일대일 상담 답변 완료 알림"),
+    VERIFICATION_CHECKED("신원 인증 검수 완료 알림"),
+    PROPERTY_MEETING_DATE_REMINDER_BEFORE_24("매물의 뷰잉가능기간 종료 24시간 전 발송"),
+    PROPERTY_MEETING_DATE_REMINDER_BEFORE_48("매물의 뷰잉가능기간 종료 48시간 전 발송"),
+
+    ;
+    private final String description;
+}

--- a/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyService.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/service/PropertyService.java
@@ -62,7 +62,7 @@ public class PropertyService {
 
     /// create
     @Transactional
-    public PropertyWithMemberResponseDTO createProperty(PropertyCreateRequestDTO dto){
+    public PropertyWithMemberResponseDTO createProperty(PropertyCreateRequestDTO dto, Long memberId){
         log.info("property 생성 로직 진입");
 
         Member findMember = memberRepository.findById(dto.memberId()).orElseThrow(() -> new CustomException(ServiceCode.MEMBER_NOT_EXISTS));

--- a/src/main/java/org/hanihome/hanihomebe/property/web/controller/PropertyController.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/controller/PropertyController.java
@@ -44,8 +44,7 @@ public class PropertyController {
 
     //read
     @GetMapping("/properties")
-    public List<?> getAll(
-            @RequestParam(required = false) PropertyViewType view) {
+    public List<?> getAll( @RequestParam(required = false) PropertyViewType view) {
 
         return propertyService.getAllProperties(view);
     }
@@ -58,9 +57,9 @@ public class PropertyController {
     // 내 매물 조회
     @GetMapping("/properties/my-properties")
     public List<?> getMyProperties(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                     @RequestParam(required = false) TradeStatus tradeStatus,
-                                                     @RequestParam(required = false) DisplayStatus displayStatus,
-                                                     @RequestParam(required = false) PropertyViewType view) {
+                                   @RequestParam(required = false) TradeStatus tradeStatus,
+                                   @RequestParam(required = false) DisplayStatus displayStatus,
+                                   @RequestParam(required = false) PropertyViewType view) {
         return propertyService.getMyProperty(userDetails.getUserId(), tradeStatus, displayStatus, view);
     }
 /*

--- a/src/main/java/org/hanihome/hanihomebe/property/web/controller/PropertyController.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/controller/PropertyController.java
@@ -12,7 +12,6 @@ import org.hanihome.hanihomebe.property.web.dto.request.PropertyCompleteTradeDTO
 import org.hanihome.hanihomebe.property.web.dto.request.create.PropertyCreateRequestDTO;
 import org.hanihome.hanihomebe.property.web.dto.request.patch.PropertyPatchRequestDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.PropertyWithMemberResponseDTO;
-import org.hanihome.hanihomebe.property.web.dto.response.basic.PropertyResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.TimeWithReserved;
 import org.hanihome.hanihomebe.security.auth.user.detail.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,7 +36,7 @@ public class PropertyController {
                                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long requesterId = userDetails.getUserId();
         PropertyWithMemberResponseDTO responseDTO = propertyService.createProperty(dto, requesterId);
-        propertyNotificationService.registerReminderNotification(requesterId, responseDTO.meetingDateTo());
+        propertyNotificationService.registerMeetingDateReminderNotification(requesterId, responseDTO.meetingDateTo());
         return responseDTO;
     }
 

--- a/src/main/java/org/hanihome/hanihomebe/property/web/controller/PropertyController.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/controller/PropertyController.java
@@ -3,6 +3,7 @@ package org.hanihome.hanihomebe.property.web.controller;
 import com.github.fge.jsonpatch.JsonPatchException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.hanihome.hanihomebe.notification.application.service.property.PropertyNotificationService;
 import org.hanihome.hanihomebe.property.application.service.PropertyService;
 import org.hanihome.hanihomebe.property.domain.enums.DisplayStatus;
 import org.hanihome.hanihomebe.property.domain.enums.TradeStatus;
@@ -27,12 +28,17 @@ import java.util.Map;
 @RestController
 public class PropertyController {
     private final PropertyService propertyService;
+    private final PropertyNotificationService propertyNotificationService;
 
 
     //create
     @PostMapping("/properties")
-    public PropertyWithMemberResponseDTO createProperty(@RequestBody @Valid PropertyCreateRequestDTO dto) {
-        return propertyService.createProperty(dto);
+    public PropertyWithMemberResponseDTO createProperty(@RequestBody @Valid PropertyCreateRequestDTO dto,
+                                                        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long requesterId = userDetails.getUserId();
+        PropertyWithMemberResponseDTO responseDTO = propertyService.createProperty(dto, requesterId);
+        propertyNotificationService.registerReminderNotification(requesterId, responseDTO.meetingDateTo());
+        return responseDTO;
     }
 
 

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/PropertyWithMemberResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/PropertyWithMemberResponseDTO.java
@@ -16,6 +16,7 @@ import org.hanihome.hanihomebe.property.web.dto.response.basic.RentPropertyRespo
 import org.hanihome.hanihomebe.property.web.dto.response.basic.SharePropertyResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.summary.MetaInfo;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -46,8 +47,8 @@ public sealed interface PropertyWithMemberResponseDTO extends PropertyDTOByView
     CostDetails costDetails();
     LivingConditions livingConditions();
     MoveInInfo moveInInfo();
-    LocalDateTime meetingDateFrom();
-    LocalDateTime meetingDateTo();
+    LocalDate meetingDateFrom();
+    LocalDate meetingDateTo();
     String description();
     MemberSummaryDTO hostSummary();
     MetaInfo metaInfo();

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/PropertyWithMemberResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/PropertyWithMemberResponseDTO.java
@@ -46,6 +46,8 @@ public sealed interface PropertyWithMemberResponseDTO extends PropertyDTOByView
     CostDetails costDetails();
     LivingConditions livingConditions();
     MoveInInfo moveInInfo();
+    LocalDateTime meetingDateFrom();
+    LocalDateTime meetingDateTo();
     String description();
     MemberSummaryDTO hostSummary();
     MetaInfo metaInfo();

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/RentPropertyWithMemberResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/RentPropertyWithMemberResponseDTO.java
@@ -33,6 +33,8 @@ public record RentPropertyWithMemberResponseDTO(
         CostDetails costDetails,
         LivingConditions livingConditions,
         MoveInInfo moveInInfo,
+        LocalDateTime meetingDateFrom,
+        LocalDateTime meetingDateTo,
         String description,
         RentInternalDetails internalDetails,
         CapacityRent capacityRent,             // (RentProperty 고유) 수용인원-렌트
@@ -61,6 +63,8 @@ public record RentPropertyWithMemberResponseDTO(
                 rentDTO.costDetails(),
                 rentDTO.livingConditions(),
                 rentDTO.moveInInfo(),
+                rentDTO.meetingDateFrom(),
+                rentDTO.meetingDateTo(),
                 rentDTO.description(),
                 rentDTO.internalDetails(),
                 rentDTO.capacityRent(),

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/RentPropertyWithMemberResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/RentPropertyWithMemberResponseDTO.java
@@ -11,6 +11,7 @@ import org.hanihome.hanihomebe.property.domain.vo.RentInternalDetails;
 import org.hanihome.hanihomebe.property.web.dto.response.basic.RentPropertyResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.summary.MetaInfo;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -33,8 +34,8 @@ public record RentPropertyWithMemberResponseDTO(
         CostDetails costDetails,
         LivingConditions livingConditions,
         MoveInInfo moveInInfo,
-        LocalDateTime meetingDateFrom,
-        LocalDateTime meetingDateTo,
+        LocalDate meetingDateFrom,
+        LocalDate meetingDateTo,
         String description,
         RentInternalDetails internalDetails,
         CapacityRent capacityRent,             // (RentProperty 고유) 수용인원-렌트

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/SharePropertyWithMemberResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/SharePropertyWithMemberResponseDTO.java
@@ -11,6 +11,7 @@ import org.hanihome.hanihomebe.property.domain.vo.ShareInternalDetails;
 import org.hanihome.hanihomebe.property.web.dto.response.basic.SharePropertyResponseDTO;
 import org.hanihome.hanihomebe.property.web.dto.response.summary.MetaInfo;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -33,8 +34,8 @@ public record SharePropertyWithMemberResponseDTO(
         CostDetails costDetails,
         LivingConditions livingConditions,
         MoveInInfo moveInInfo,
-        LocalDateTime meetingDateFrom,
-        LocalDateTime meetingDateTo,
+        LocalDate meetingDateFrom,
+        LocalDate meetingDateTo,
         String description,
         ShareInternalDetails internalDetails,                       // 2-6. 해당 매물의 층수
         CapacityShare capacityShare,                             // 3. 수용 인원

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/SharePropertyWithMemberResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/SharePropertyWithMemberResponseDTO.java
@@ -33,6 +33,8 @@ public record SharePropertyWithMemberResponseDTO(
         CostDetails costDetails,
         LivingConditions livingConditions,
         MoveInInfo moveInInfo,
+        LocalDateTime meetingDateFrom,
+        LocalDateTime meetingDateTo,
         String description,
         ShareInternalDetails internalDetails,                       // 2-6. 해당 매물의 층수
         CapacityShare capacityShare,                             // 3. 수용 인원
@@ -61,6 +63,8 @@ public record SharePropertyWithMemberResponseDTO(
                 shareDTO.costDetails(),
                 shareDTO.livingConditions(),
                 shareDTO.moveInInfo(),
+                shareDTO.meetingDateFrom(),
+                shareDTO.meetingDateTo(),
                 shareDTO.description(),
                 shareDTO.internalDetails(),
                 shareDTO.capacityShare(),

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/PropertyResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/PropertyResponseDTO.java
@@ -41,5 +41,7 @@ public sealed interface PropertyResponseDTO
     CostDetails costDetails();
     LivingConditions livingConditions();
     MoveInInfo moveInInfo();
+    LocalDateTime meetingDateFrom();
+    LocalDateTime meetingDateTo();
     String description();
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/PropertyResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/PropertyResponseDTO.java
@@ -10,6 +10,7 @@ import org.hanihome.hanihomebe.property.domain.vo.MoveInInfo;
 import org.hanihome.hanihomebe.property.domain.enums.*;
 import org.hanihome.hanihomebe.property.web.dto.response.PropertyDTOByView;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -41,7 +42,7 @@ public sealed interface PropertyResponseDTO
     CostDetails costDetails();
     LivingConditions livingConditions();
     MoveInInfo moveInInfo();
-    LocalDateTime meetingDateFrom();
-    LocalDateTime meetingDateTo();
+    LocalDate meetingDateFrom();
+    LocalDate meetingDateTo();
     String description();
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/RentPropertyResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/RentPropertyResponseDTO.java
@@ -30,6 +30,8 @@ public record RentPropertyResponseDTO(
         CostDetails costDetails,
         LivingConditions livingConditions,
         MoveInInfo moveInInfo,
+        LocalDateTime meetingDateFrom,
+        LocalDateTime meetingDateTo,
         String description,
         RentInternalDetails internalDetails,
         CapacityRent capacityRent                  // (RentProperty 고유) 수용인원-렌트

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/RentPropertyResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/RentPropertyResponseDTO.java
@@ -8,6 +8,7 @@ import org.hanihome.hanihomebe.property.domain.vo.LivingConditions;
 import org.hanihome.hanihomebe.property.domain.vo.MoveInInfo;
 import org.hanihome.hanihomebe.property.domain.vo.RentInternalDetails;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -30,8 +31,8 @@ public record RentPropertyResponseDTO(
         CostDetails costDetails,
         LivingConditions livingConditions,
         MoveInInfo moveInInfo,
-        LocalDateTime meetingDateFrom,
-        LocalDateTime meetingDateTo,
+        LocalDate meetingDateFrom,
+        LocalDate meetingDateTo,
         String description,
         RentInternalDetails internalDetails,
         CapacityRent capacityRent                  // (RentProperty 고유) 수용인원-렌트
@@ -73,6 +74,8 @@ public record RentPropertyResponseDTO(
                 rentProperty.getCostDetails(),
                 rentProperty.getLivingConditions(),
                 rentProperty.getMoveInInfo(),
+                rentProperty.getMeetingDateFrom(),
+                rentProperty.getMeetingDateTo(),
                 rentProperty.getDescription(),
                 // rent 고유 정보
                 rentProperty.getRentInternalDetails(),

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/SharePropertyResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/SharePropertyResponseDTO.java
@@ -9,6 +9,7 @@ import org.hanihome.hanihomebe.property.domain.vo.LivingConditions;
 import org.hanihome.hanihomebe.property.domain.vo.MoveInInfo;
 import org.hanihome.hanihomebe.property.domain.vo.ShareInternalDetails;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -31,8 +32,8 @@ public record SharePropertyResponseDTO(
         CostDetails costDetails,
         LivingConditions livingConditions,
         MoveInInfo moveInInfo,
-        LocalDateTime meetingDateFrom,
-        LocalDateTime meetingDateTo,
+        LocalDate meetingDateFrom,
+        LocalDate meetingDateTo,
         String description,
         ShareInternalDetails internalDetails,                       // 2-6. 해당 매물의 층수
         CapacityShare capacityShare                             // 3. 수용 인원
@@ -78,6 +79,8 @@ public record SharePropertyResponseDTO(
                 shareProperty.getCostDetails(),
                 shareProperty.getLivingConditions(),
                 shareProperty.getMoveInInfo(),
+                shareProperty.getMeetingDateFrom(),
+                shareProperty.getMeetingDateTo(),
                 shareProperty.getDescription(),
                 // share 고유정보
                 shareProperty.getShareInternalDetails(),

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/SharePropertyResponseDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/response/basic/SharePropertyResponseDTO.java
@@ -31,6 +31,8 @@ public record SharePropertyResponseDTO(
         CostDetails costDetails,
         LivingConditions livingConditions,
         MoveInInfo moveInInfo,
+        LocalDateTime meetingDateFrom,
+        LocalDateTime meetingDateTo,
         String description,
         ShareInternalDetails internalDetails,                       // 2-6. 해당 매물의 층수
         CapacityShare capacityShare                             // 3. 수용 인원

--- a/src/main/java/org/hanihome/hanihomebe/verification/service/VerificationNotificationService.java
+++ b/src/main/java/org/hanihome/hanihomebe/verification/service/VerificationNotificationService.java
@@ -2,7 +2,7 @@ package org.hanihome.hanihomebe.verification.service;
 
 import lombok.RequiredArgsConstructor;
 import org.hanihome.hanihomebe.notification.application.service.NotificationFacadeService;
-import org.hanihome.hanihomebe.notification.application.service.NotificationMessageFactory;
+import org.hanihome.hanihomebe.notification.application.service.factory.NotificationMessageFactory;
 import org.hanihome.hanihomebe.notification.web.dto.NotificationCreateDTO;
 import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
@@ -12,12 +12,12 @@ public class VerificationNotificationService {
     private final NotificationMessageFactory messageFactory;
 
     public void sendRejectNotification(Long verificationId, String reason) {
-        NotificationCreateDTO message = messageFactory.createVerificationRejectMessage(verificationId, reason);
+        NotificationCreateDTO message = messageFactory.getVerificationMessageCreator().createVerificationRejectMessage(verificationId, reason);
         notificationFacadeService.sendNotification(message);
     }
 
     public void sendApproveNotification(Long verificationId) {
-        NotificationCreateDTO message = messageFactory.createVerificationApproveMessage(verificationId);
+        NotificationCreateDTO message = messageFactory.getVerificationMessageCreator().createVerificationApproveMessage(verificationId);
         notificationFacadeService.sendNotification(message);
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/verification/web/VerificationController.java
+++ b/src/main/java/org/hanihome/hanihomebe/verification/web/VerificationController.java
@@ -2,8 +2,6 @@ package org.hanihome.hanihomebe.verification.web;
 
 
 import lombok.RequiredArgsConstructor;
-import org.hanihome.hanihomebe.notification.application.service.NotificationFacadeService;
-import org.hanihome.hanihomebe.notification.application.service.NotificationMessageFactory;
 import org.hanihome.hanihomebe.security.auth.user.detail.CustomUserDetails;
 import org.hanihome.hanihomebe.verification.service.VerificationNotificationService;
 import org.hanihome.hanihomebe.verification.service.VerificationService;
@@ -29,8 +27,6 @@ import java.util.List;
 public class VerificationController {
 
     private final VerificationService verificationService;
-    private final NotificationFacadeService notificationFacadeService;
-    private final NotificationMessageFactory messageFactory;
     private final VerificationNotificationService verificationNotificationService;
 
     /*

--- a/src/main/java/org/hanihome/hanihomebe/viewing/web/controller/ViewingController.java
+++ b/src/main/java/org/hanihome/hanihomebe/viewing/web/controller/ViewingController.java
@@ -3,7 +3,7 @@ package org.hanihome.hanihomebe.viewing.web.controller;
 import lombok.RequiredArgsConstructor;
 import org.hanihome.hanihomebe.viewing.web.dto.ViewingBelongsToPropertyDTO;
 import org.hanihome.hanihomebe.security.auth.user.detail.CustomUserDetails;
-import org.hanihome.hanihomebe.viewing.application.service.ViewingNotificationService;
+import org.hanihome.hanihomebe.notification.application.service.viewing.ViewingNotificationService;
 import org.hanihome.hanihomebe.viewing.application.service.ViewingService;
 import org.hanihome.hanihomebe.viewing.domain.ViewingStatus;
 import org.hanihome.hanihomebe.viewing.web.dto.ViewingDTOByView;
@@ -44,7 +44,7 @@ public class ViewingController {
         Long viewingId = responseDTO.getId();
         viewingNotificationService.sendViewingCreateNotification(userDetails.getUsername(), viewingId);
         // 3. 뷰잉 리마인더 알림 스케줄링
-        viewingNotificationService.sendReminderNotification(viewingId, responseDTO.getMeetingDay());
+        viewingNotificationService.registerReminderNotification(viewingId, responseDTO.getMeetingDay());
         return responseDTO;
     }
 

--- a/src/test/java/org/hanihome/hanihomebe/property/application/service/PropertySearchServiceTest.java
+++ b/src/test/java/org/hanihome/hanihomebe/property/application/service/PropertySearchServiceTest.java
@@ -220,10 +220,10 @@ class PropertySearchServiceTest {
                         CapacityRent.FOUR
                 );
 
-        propertyService.createProperty(share_masterRoom);
-        propertyService.createProperty(share_secondRoom);
-        propertyService.createProperty(rent_house);
-        propertyService.createProperty(rent_unit);
+        propertyService.createProperty(share_masterRoom, memberId);
+        propertyService.createProperty(share_secondRoom, memberId);
+        propertyService.createProperty(rent_house, memberId);
+        propertyService.createProperty(rent_unit, memberId);
     }
     /// 매물 종류
     @Test
@@ -443,7 +443,7 @@ class PropertySearchServiceTest {
                         ),                      // internalDetails
                         CapacityShare.DOUBLE       // capacityShare
                 );
-        propertyService.createProperty(dto);
+        propertyService.createProperty(dto, memberId);
         List<PropertySummaryDTO> results = propertySearchService.search(
                 PropertySearchConditionDTO.builder()
                         .availableFrom(LocalDateTime.of(2025, 5, 11, 5, 5))

--- a/src/test/java/org/hanihome/hanihomebe/property/application/service/PropertyServiceTest.java
+++ b/src/test/java/org/hanihome/hanihomebe/property/application/service/PropertyServiceTest.java
@@ -116,7 +116,7 @@ class PropertyServiceTest {
         SharePropertyCreateRequestDTO dto = buildSharePropertyDTO(memberId);
 
         // When
-        var result = propertyService.createProperty(dto);
+        var result = propertyService.createProperty(dto, memberId);
 
         // Then
         assertThat(propertyService.getPropertyById(result.id()).memberId())
@@ -128,7 +128,7 @@ class PropertyServiceTest {
     void bookingAndDealFlow() {
         // Given: 호스트가 매물 등록
         SharePropertyCreateRequestDTO dto = buildSharePropertyDTO(memberId);
-        PropertyWithMemberResponseDTO created = propertyService.createProperty(dto);
+        PropertyWithMemberResponseDTO created = propertyService.createProperty(dto, memberId);
         Long propertyId = created.id();
 
         // Given: Member2, Member3 생성
@@ -191,7 +191,7 @@ class PropertyServiceTest {
     void bookingAndDealFlow_RentProperty() {
         // Given: 호스트가 매물 등록
         RentPropertyCreateRequestDTO dto = buildRentPropertyDTO(memberId);
-        PropertyWithMemberResponseDTO created = propertyService.createProperty(dto);
+        PropertyWithMemberResponseDTO created = propertyService.createProperty(dto, memberId);
         Long propertyId = created.id();
 
         // Given: Member2, Member3 생성


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #230 
1. 매물의 뷰잉 예약가능기간 24/48시간 전에 알림이 전송되도록 구현
2. 기존 알림 클래스 리팩토링
- TaskScheduler는 보다 범용적인 작업을 담당하므로 뷰잉/매물 등 다른 엔티티 모두에도 사용가능함을 알리도록 네이밍 변경
- 기존에는 하나의 클래스에서 모든 엔티티의 메시지를 생성했음. -> 서로 다른 관심사가 섞이므로 매우 비가시적. 따라서 다형성 적용하여 변경. 
  - MessageFactory 도입
  - MessageCreator 인터페이스 사용 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->


## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
