### PR TITLE
[FIX] 매물 등록 - 뷰잉 항상 가능 요청 시 meetingDateFrom, to 미설정 오류 해결

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/property/application/time/PropertyCreateTimeManager.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/time/PropertyCreateTimeManager.java
@@ -24,11 +24,8 @@ public class PropertyCreateTimeManager {
     }
 
 
-    public static List<ViewingAvailableDateTime> validateAndGenerateTowMonthsOfViewingAvailableDateTimes(List<TimeSlot> timeSlots) {
+    public static List<ViewingAvailableDateTime> validateAndGenerateTwoMonthsOfViewingAvailableDateTimes(List<TimeSlot> timeSlots, MeetingDatePeriod meetingDatePeriod) {
         validateTimeSlots(timeSlots);
-
-        MeetingDatePeriod meetingDatePeriod = buildTwoMonths();
-
         return generateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
     }
 
@@ -39,7 +36,7 @@ public class PropertyCreateTimeManager {
         }
     }
 
-    private static MeetingDatePeriod buildTwoMonths() {
+    public static MeetingDatePeriod buildTwoMonths() {
         LocalDate meetingDateFrom = LocalDateTime
                 .now(ZoneId.of("UTC")).
                 toLocalDate() ;

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/RentPropertyCreateRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/RentPropertyCreateRequestDTO.java
@@ -57,7 +57,10 @@ public record RentPropertyCreateRequestDTO(
 
         // 타임슬롯 검증, 뷰잉 가능 시간 생성
         if (viewingAlwaysAvailable) {
-            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateTowMonthsOfViewingAvailableDateTimes(timeSlots);
+            MeetingDatePeriod meetingDatePeriod = PropertyCreateTimeManager.buildTwoMonths();
+            meetingDateFrom = meetingDatePeriod.meetingDateFrom();
+            meetingDateTo = meetingDatePeriod.meetingDateTo();
+            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateTwoMonthsOfViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
         } else {
             MeetingDatePeriod meetingDatePeriod = MeetingDatePeriod.create(meetingDateFrom, meetingDateTo);
             viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/SharePropertyCreateRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/SharePropertyCreateRequestDTO.java
@@ -1,13 +1,9 @@
 package org.hanihome.hanihomebe.property.web.dto.request.create;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hanihome.hanihomebe.global.exception.CustomException;
-import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.interest.region.Region;
 import org.hanihome.hanihomebe.property.application.time.MeetingDatePeriod;
 import org.hanihome.hanihomebe.property.application.time.PropertyCreateTimeManager;
-import org.hanihome.hanihomebe.property.application.time.generator.ViewingAvailableDateTimeGenerator;
-import org.hanihome.hanihomebe.property.application.time.validator.TimeSlotValidator;
 import org.hanihome.hanihomebe.property.domain.enums.*;
 import org.hanihome.hanihomebe.property.domain.vo.*;
 
@@ -54,7 +50,10 @@ public record SharePropertyCreateRequestDTO(
 
         // 타임슬롯 검증, 뷰잉 가능 시간 생성
         if (viewingAlwaysAvailable) {
-            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateTowMonthsOfViewingAvailableDateTimes(timeSlots);
+            MeetingDatePeriod meetingDatePeriod = PropertyCreateTimeManager.buildTwoMonths();
+            meetingDateFrom = meetingDatePeriod.meetingDateFrom();
+            meetingDateTo = meetingDatePeriod.meetingDateTo();
+            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateTwoMonthsOfViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
         } else {
             MeetingDatePeriod meetingDatePeriod = MeetingDatePeriod.create(meetingDateFrom, meetingDateTo);
             viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #233


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
문제: 뷰잉 항상 가능 옵션일 때 DTO에서 ViewingAvailableDateTime 엔티티만 만들고, meetingDateFrom/To는 DTO에 주입안함
해결: 이제 meetingDateFrom/To 필드도 생성자에서 자동 초기화하도록 하여 Property엔티티의 필드에 null값이 가지 않도록 처리함

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
