### PR TITLE
[FIX]#236 매물 등록 - timeSlot.timeTo가 00시 일 때 뷰잉가능시각 설정 안되던 오류 해결

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/property/application/time/generator/ViewingAvailableDateTimeGenerator.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/time/generator/ViewingAvailableDateTimeGenerator.java
@@ -7,6 +7,7 @@ import org.hanihome.hanihomebe.viewing.domain.ViewingTimeInterval;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,14 +23,16 @@ public class ViewingAvailableDateTimeGenerator {
             LocalDate finalTempDate = pos;
             timeSlots.forEach(timeSlot -> {
                 LocalTime timeFrom = timeSlot.getTimeFrom();
-                LocalTime timeTo = timeSlot.getTimeTo();
-                while(timeFrom.isBefore(timeTo)) {
-                    ViewingAvailableDateTime viewingAvailableDateTime = new ViewingAvailableDateTime(finalTempDate,
-                            timeFrom,
+                LocalDateTime start = LocalDateTime.of(finalTempDate, timeFrom);
+                LocalDateTime end = getEndTime(timeSlot, timeFrom, finalTempDate);
+
+                while(start.isBefore(end)) {
+                    ViewingAvailableDateTime viewingAvailableDateTime = new ViewingAvailableDateTime(start.toLocalDate(),
+                            start.toLocalTime(),
                             false,
                             ViewingTimeInterval.MINUTE30);
                     viewingAvailableDateTimes.add(viewingAvailableDateTime);
-                    timeFrom = timeFrom.plusMinutes(30);
+                    start = start.plusMinutes(30);
                 }
             });
             pos = pos.plusDays(1);
@@ -38,5 +41,16 @@ public class ViewingAvailableDateTimeGenerator {
         log.info("viewingAvailableDateTimes: {}", viewingAvailableDateTimes.stream().map(viewingAvailableDateTime -> viewingAvailableDateTime.getTime()).toList());
 
         return viewingAvailableDateTimes;
+    }
+
+    private static LocalDateTime getEndTime(TimeSlot timeSlot, LocalTime timeFrom, LocalDate finalTempDate) {
+        LocalTime timeTo = timeSlot.getTimeTo();
+        LocalDateTime end;
+        if (timeTo.equals(LocalTime.MIDNIGHT) && timeFrom.isAfter(timeTo)) {
+            end = LocalDateTime.of(finalTempDate.plusDays(1), LocalTime.MIDNIGHT);
+        } else {
+            end = LocalDateTime.of(finalTempDate, timeTo);
+        }
+        return end;
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/domain/Property.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/domain/Property.java
@@ -15,6 +15,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -201,10 +202,19 @@ public abstract class Property {
         }
     }
 
+    public List<ViewingAvailableDateTime> getViewingAvailableDateTimesAfterNow() {
+        LocalDateTime now = LocalDateTime.now();
+        return viewingAvailableDateTimes
+                .stream()
+                .filter(availableTime -> {
+                    LocalDate date = availableTime.getDate();
+                    LocalTime time = availableTime.getTime();
+                    LocalDateTime dateTime = LocalDateTime.of(date, time);
+                    return dateTime.isEqual(now) || dateTime.isAfter(now);
+                })
+                .toList();
+    }
 
-    /**
-     * 공통 DTO 변환 메서드
-     */
     public void addPropertyOptionItem(PropertyOptionItem propertyOptionItem) {
         optionItems.add(propertyOptionItem);
         propertyOptionItem.setProperty(this);


### PR DESCRIPTION
기존: 20~00시 처리를 못하였음
변경: 20~00시 처리는 20~24시와 동일하게 처리

<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #236 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
끝시간이 00시이고 시작시간이 20시 처럼 00시보다 값이 큰 경우에 대한 별도의 조건처리를 하였습니다.
기존: timeFrom=20, timeTo=00 일 때 ViewingAvailableDateTime 엔티티 미생성된다.
변경: 20~23:30까지 ViewingAvailableDateTime 생성

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
