### PR TITLE
[FIX]#245 매물 생성 / TimeSlot 처리 및 ViewingAvailableDateTime 생성 리팩토링 및 null 허용

### DIFF
--- a/src/main/java/org/hanihome/hanihomebe/property/application/time/PropertyCreateTimeManager.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/application/time/PropertyCreateTimeManager.java
@@ -10,30 +10,31 @@ import org.hanihome.hanihomebe.property.domain.vo.ViewingAvailableDateTime;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class PropertyCreateTimeManager {
+    public static List<TimeSlot> preprocessTimeSlots(List<TimeSlot> timeSlots) {
+        if (timeSlots == null) {
+            return Collections.emptyList();
+        }
+
+        return timeSlots.stream()
+                .filter(timeSlot -> !(timeSlot.getTimeFrom() == null && timeSlot.getTimeTo() == null))
+                .peek(timeSlot -> {
+                    if (timeSlot.getTimeFrom() == null || timeSlot.getTimeTo() == null) {
+                        throw new CustomException(ServiceCode.INVALID_PROPERTY_TIME_SLOT);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
     public static List<ViewingAvailableDateTime> validateAndGenerateViewingAvailableDateTimes(List<TimeSlot> timeSlots,
                                                                                               MeetingDatePeriod meetingDatePeriod) {
-        // 뷰잉 가능 시간 검증
         validateTimeSlots(timeSlots);
-
-        // ViewingAvailableDateTime 변환
         List<ViewingAvailableDateTime> generated = generateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
         return generated;
-    }
-
-
-    public static List<ViewingAvailableDateTime> validateAndGenerateTwoMonthsOfViewingAvailableDateTimes(List<TimeSlot> timeSlots, MeetingDatePeriod meetingDatePeriod) {
-        validateTimeSlots(timeSlots);
-        return generateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
-    }
-
-    private static void validateTimeSlots(List<TimeSlot> timeSlots) {
-        boolean isValidTimeSlots = TimeSlotValidator.validateAllConditions(timeSlots);
-        if(!isValidTimeSlots) {
-            throw new CustomException(ServiceCode.INVALID_PROPERTY_TIME_SLOT);
-        }
     }
 
     public static MeetingDatePeriod buildTwoMonths() {
@@ -43,6 +44,13 @@ public class PropertyCreateTimeManager {
         LocalDate meetingDateTo = meetingDateFrom.plusMonths(2);
         MeetingDatePeriod meetingDatePeriod = MeetingDatePeriod.create(meetingDateFrom, meetingDateTo);
         return meetingDatePeriod;
+    }
+
+    private static void validateTimeSlots(List<TimeSlot> timeSlots) {
+        boolean isValidTimeSlots = TimeSlotValidator.validateAllConditions(timeSlots);
+        if(!isValidTimeSlots) {
+            throw new CustomException(ServiceCode.INVALID_PROPERTY_TIME_SLOT);
+        }
     }
 
     private static List<ViewingAvailableDateTime> generateViewingAvailableDateTimes(List<TimeSlot> timeSlots, MeetingDatePeriod meetingDatePeriod) {

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/ProcessedViewingDatesDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/ProcessedViewingDatesDTO.java
@@ -1,0 +1,14 @@
+package org.hanihome.hanihomebe.property.web.dto.request.create;
+
+import org.hanihome.hanihomebe.property.domain.vo.TimeSlot;
+import org.hanihome.hanihomebe.property.domain.vo.ViewingAvailableDateTime;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ProcessedViewingDatesDTO(
+        LocalDate processedMeetingDateFrom,
+        LocalDate processedMeetingDateTo,
+        List<TimeSlot> processedTimeSlots,
+        List<ViewingAvailableDateTime> viewingAvailableDateTimes
+) { }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/PropertyCreateRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/PropertyCreateRequestDTO.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.hanihome.hanihomebe.global.exception.CustomException;
 import org.hanihome.hanihomebe.global.response.domain.ServiceCode;
 import org.hanihome.hanihomebe.interest.region.Region;
+import org.hanihome.hanihomebe.property.application.time.MeetingDatePeriod;
+import org.hanihome.hanihomebe.property.application.time.PropertyCreateTimeManager;
 import org.hanihome.hanihomebe.property.domain.enums.GenderPreference;
 import org.hanihome.hanihomebe.property.domain.enums.PropertySuperType;
 import org.hanihome.hanihomebe.property.domain.vo.*;
@@ -63,5 +65,14 @@ public sealed interface PropertyCreateRequestDTO permits
                 latitude.compareTo(BigDecimal.valueOf(90)) <= 0 &&
                 longitude.compareTo(BigDecimal.valueOf(-180)) >= 0 &&
                 longitude.compareTo(BigDecimal.valueOf(180)) <= 0;
+    }
+
+    default ProcessedViewingDatesDTO processViewingDates(List<TimeSlot> timeSlots, MeetingDatePeriod meetingDatePeriod) {
+        List<TimeSlot> processedTimeSlots = PropertyCreateTimeManager.preprocessTimeSlots(timeSlots);
+        LocalDate meetingDateFrom = meetingDatePeriod.meetingDateFrom();
+        LocalDate meetingDateTo = meetingDatePeriod.meetingDateTo();
+        List<ViewingAvailableDateTime> viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateViewingAvailableDateTimes(processedTimeSlots, meetingDatePeriod);
+
+        return new ProcessedViewingDatesDTO(meetingDateFrom, meetingDateTo, processedTimeSlots, viewingAvailableDateTimes);
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/RentPropertyCreateRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/RentPropertyCreateRequestDTO.java
@@ -56,14 +56,16 @@ public record RentPropertyCreateRequestDTO(
         }
 
         // 타임슬롯 검증, 뷰잉 가능 시간 생성
+        MeetingDatePeriod meetingDatePeriod;
         if (viewingAlwaysAvailable) {
-            MeetingDatePeriod meetingDatePeriod = PropertyCreateTimeManager.buildTwoMonths();
-            meetingDateFrom = meetingDatePeriod.meetingDateFrom();
-            meetingDateTo = meetingDatePeriod.meetingDateTo();
-            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateTwoMonthsOfViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
+            meetingDatePeriod = PropertyCreateTimeManager.buildTwoMonths();
         } else {
-            MeetingDatePeriod meetingDatePeriod = MeetingDatePeriod.create(meetingDateFrom, meetingDateTo);
-            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
+            meetingDatePeriod = MeetingDatePeriod.create(meetingDateFrom, meetingDateTo);
         }
+        ProcessedViewingDatesDTO processed = processViewingDates(timeSlots, meetingDatePeriod);
+        meetingDateFrom = processed.processedMeetingDateFrom();
+        meetingDateTo = processed.processedMeetingDateTo();
+        timeSlots = processed.processedTimeSlots();
+        viewingAvailableDateTimes = processed.viewingAvailableDateTimes();
     }
 }

--- a/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/SharePropertyCreateRequestDTO.java
+++ b/src/main/java/org/hanihome/hanihomebe/property/web/dto/request/create/SharePropertyCreateRequestDTO.java
@@ -49,14 +49,16 @@ public record SharePropertyCreateRequestDTO(
         }
 
         // 타임슬롯 검증, 뷰잉 가능 시간 생성
+        MeetingDatePeriod meetingDatePeriod;
         if (viewingAlwaysAvailable) {
-            MeetingDatePeriod meetingDatePeriod = PropertyCreateTimeManager.buildTwoMonths();
-            meetingDateFrom = meetingDatePeriod.meetingDateFrom();
-            meetingDateTo = meetingDatePeriod.meetingDateTo();
-            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateTwoMonthsOfViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
+            meetingDatePeriod = PropertyCreateTimeManager.buildTwoMonths();
         } else {
-            MeetingDatePeriod meetingDatePeriod = MeetingDatePeriod.create(meetingDateFrom, meetingDateTo);
-            viewingAvailableDateTimes = PropertyCreateTimeManager.validateAndGenerateViewingAvailableDateTimes(timeSlots, meetingDatePeriod);
+            meetingDatePeriod = MeetingDatePeriod.create(meetingDateFrom, meetingDateTo);
         }
+        ProcessedViewingDatesDTO processed = processViewingDates(timeSlots, meetingDatePeriod);
+        meetingDateFrom = processed.processedMeetingDateFrom();
+        meetingDateTo = processed.processedMeetingDateTo();
+        timeSlots = processed.processedTimeSlots();
+        viewingAvailableDateTimes = processed.viewingAvailableDateTimes();
     }
 }


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #245 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
1. 요청 바디로 TimeSlot이 null 값이 전달되는 경우에 대해 유연하게 허용하도록 변경하였습니다. 이제 모두 timeFrom, timeTo가 모두 null인 경우 해당 tiemSlot은 제거된 채로 `PropertyCreateDTO`가 생성됩니다.
2. 쉐어/렌트에 따라 매번 `PropertyCreateTimeManager`를 호출하는 것이 번거로웠기에 interface에서 default함수를 사용하여 코드 재사용성을 높였습니다.

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
